### PR TITLE
feat: foundation — cargo workspace, shared types, REST API, auth, and tests

### DIFF
--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -21,18 +21,13 @@ pub enum Color {
 }
 
 /// Content of a single board cell.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum CellContent {
     Char(char),
     Color(Color),
+    #[default]
     Blank,
-}
-
-impl Default for CellContent {
-    fn default() -> Self {
-        Self::Blank
-    }
 }
 
 /// Horizontal text alignment.
@@ -112,19 +107,16 @@ pub struct Message {
 // ── Countdowns ────────────────────────────────────────────────────
 
 /// Behavior when a countdown reaches zero.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum ZeroBehavior {
+    #[default]
     ShowZero,
-    ShowMessage { grid: Grid },
+    ShowMessage {
+        grid: Grid,
+    },
     Remove,
     Pause,
-}
-
-impl Default for ZeroBehavior {
-    fn default() -> Self {
-        Self::ShowZero
-    }
 }
 
 /// A countdown timer entry.

--- a/crates/herald-server/src/api/config.rs
+++ b/crates/herald-server/src/api/config.rs
@@ -1,5 +1,5 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 
 use super::ApiError;
 use crate::db;

--- a/crates/herald-server/src/api/countdowns.rs
+++ b/crates/herald-server/src/api/countdowns.rs
@@ -1,7 +1,7 @@
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use chrono::Utc;
 use uuid::Uuid;
 

--- a/crates/herald-server/src/api/health.rs
+++ b/crates/herald-server/src/api/health.rs
@@ -1,5 +1,5 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 
 use crate::db;
 use crate::state::AppState;

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -1,7 +1,7 @@
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use chrono::Utc;
 use uuid::Uuid;
 
@@ -15,9 +15,7 @@ pub async fn create(
     Json(req): Json<CreateMessageRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     // Validate grid dimensions
-    req.grid
-        .validate()
-        .map_err(|e| ApiError::BadRequest(e))?;
+    req.grid.validate().map_err(ApiError::BadRequest)?;
 
     let position = match req.queue_position {
         Some(p) => p,
@@ -39,9 +37,7 @@ pub async fn create(
     Ok((StatusCode::CREATED, Json(msg)))
 }
 
-pub async fn list(
-    State(state): State<AppState>,
-) -> Result<Json<ListResponse<Message>>, ApiError> {
+pub async fn list(State(state): State<AppState>) -> Result<Json<ListResponse<Message>>, ApiError> {
     let messages = db::list_messages(state.pool()).await?;
     let total = messages.len();
     Ok(Json(ListResponse {
@@ -67,7 +63,7 @@ pub async fn update(
 ) -> Result<Json<Message>, ApiError> {
     // Validate grid if provided
     if let Some(ref grid) = req.grid {
-        grid.validate().map_err(|e| ApiError::BadRequest(e))?;
+        grid.validate().map_err(ApiError::BadRequest)?;
     }
 
     let updated = db::update_message(state.pool(), &id, &req).await?;

--- a/crates/herald-server/src/api/mod.rs
+++ b/crates/herald-server/src/api/mod.rs
@@ -5,9 +5,9 @@ pub mod health;
 pub mod messages;
 pub mod queue;
 
+use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use herald_common::ErrorResponse;
 
 /// Unified API error type.

--- a/crates/herald-server/src/api/queue.rs
+++ b/crates/herald-server/src/api/queue.rs
@@ -1,14 +1,12 @@
-use axum::extract::State;
 use axum::Json;
+use axum::extract::State;
 
 use super::ApiError;
 use crate::db;
 use crate::state::AppState;
 use herald_common::*;
 
-pub async fn list(
-    State(state): State<AppState>,
-) -> Result<Json<QueueListResponse>, ApiError> {
+pub async fn list(State(state): State<AppState>) -> Result<Json<QueueListResponse>, ApiError> {
     let items = db::get_queue(state.pool()).await?;
     let current_index = db::get_current_index(state.pool()).await?;
     let total = items.len();
@@ -28,8 +26,7 @@ pub async fn reorder(
     let current_items = db::get_queue(state.pool()).await?;
     let current_ids: std::collections::HashSet<uuid::Uuid> =
         current_items.iter().map(|i| i.id).collect();
-    let request_ids: std::collections::HashSet<uuid::Uuid> =
-        req.order.iter().copied().collect();
+    let request_ids: std::collections::HashSet<uuid::Uuid> = req.order.iter().copied().collect();
 
     if current_ids != request_ids {
         return Err(ApiError::BadRequest(

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -23,13 +23,14 @@ pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
 
 // ── Messages ──────────────────────────────────────────────────────
 
-pub async fn create_message(
-    pool: &SqlitePool,
-    msg: &Message,
-) -> Result<(), sqlx::Error> {
+pub async fn create_message(pool: &SqlitePool, msg: &Message) -> Result<(), sqlx::Error> {
     let grid_json = serde_json::to_string(&msg.grid).unwrap();
-    let h_align = serde_json::to_string(&msg.h_align).unwrap().replace('"', "");
-    let v_align = serde_json::to_string(&msg.v_align).unwrap().replace('"', "");
+    let h_align = serde_json::to_string(&msg.h_align)
+        .unwrap()
+        .replace('"', "");
+    let v_align = serde_json::to_string(&msg.v_align)
+        .unwrap()
+        .replace('"', "");
     let id = msg.id.to_string();
     let created = msg.created_at.to_rfc3339();
     let expires = msg.expires_at.map(|d| d.to_rfc3339());
@@ -56,13 +57,10 @@ pub async fn list_messages(pool: &SqlitePool) -> Result<Vec<Message>, sqlx::Erro
         .fetch_all(pool)
         .await?;
 
-    Ok(rows.iter().map(|r| row_to_message(r)).collect())
+    Ok(rows.iter().map(row_to_message).collect())
 }
 
-pub async fn get_message(
-    pool: &SqlitePool,
-    id: &str,
-) -> Result<Option<Message>, sqlx::Error> {
+pub async fn get_message(pool: &SqlitePool, id: &str) -> Result<Option<Message>, sqlx::Error> {
     let row = sqlx::query("SELECT * FROM messages WHERE id = ?")
         .bind(id)
         .fetch_optional(pool)
@@ -125,10 +123,7 @@ pub async fn update_message(
     Ok(result.rows_affected() > 0)
 }
 
-pub async fn delete_message(
-    pool: &SqlitePool,
-    id: &str,
-) -> Result<bool, sqlx::Error> {
+pub async fn delete_message(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
     let result = sqlx::query("DELETE FROM messages WHERE id = ?")
         .bind(id)
         .execute(pool)
@@ -163,10 +158,7 @@ fn row_to_message(row: &sqlx::sqlite::SqliteRow) -> Message {
 
 // ── Countdowns ────────────────────────────────────────────────────
 
-pub async fn create_countdown(
-    pool: &SqlitePool,
-    cd: &Countdown,
-) -> Result<(), sqlx::Error> {
+pub async fn create_countdown(pool: &SqlitePool, cd: &Countdown) -> Result<(), sqlx::Error> {
     let id = cd.id.to_string();
     let target = cd.target.to_rfc3339();
     let zero_json = serde_json::to_string(&cd.zero_behavior).unwrap();
@@ -190,18 +182,14 @@ pub async fn create_countdown(
 }
 
 pub async fn list_countdowns(pool: &SqlitePool) -> Result<Vec<Countdown>, sqlx::Error> {
-    let rows =
-        sqlx::query("SELECT * FROM countdowns ORDER BY queue_position ASC, created_at ASC")
-            .fetch_all(pool)
-            .await?;
+    let rows = sqlx::query("SELECT * FROM countdowns ORDER BY queue_position ASC, created_at ASC")
+        .fetch_all(pool)
+        .await?;
 
-    Ok(rows.iter().map(|r| row_to_countdown(r)).collect())
+    Ok(rows.iter().map(row_to_countdown).collect())
 }
 
-pub async fn get_countdown(
-    pool: &SqlitePool,
-    id: &str,
-) -> Result<Option<Countdown>, sqlx::Error> {
+pub async fn get_countdown(pool: &SqlitePool, id: &str) -> Result<Option<Countdown>, sqlx::Error> {
     let row = sqlx::query("SELECT * FROM countdowns WHERE id = ?")
         .bind(id)
         .fetch_optional(pool)
@@ -254,10 +242,7 @@ pub async fn update_countdown(
     Ok(result.rows_affected() > 0)
 }
 
-pub async fn delete_countdown(
-    pool: &SqlitePool,
-    id: &str,
-) -> Result<bool, sqlx::Error> {
+pub async fn delete_countdown(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
     let result = sqlx::query("DELETE FROM countdowns WHERE id = ?")
         .bind(id)
         .execute(pool)
@@ -383,10 +368,7 @@ fn derive_message_label(grid_json: &str) -> String {
 }
 
 /// Reorder queue items: rewrite queue_position for both messages and countdowns.
-pub async fn reorder_queue(
-    pool: &SqlitePool,
-    order: &[uuid::Uuid],
-) -> Result<(), sqlx::Error> {
+pub async fn reorder_queue(pool: &SqlitePool, order: &[uuid::Uuid]) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
     for (pos, id) in order.iter().enumerate() {

--- a/crates/herald-server/src/lib.rs
+++ b/crates/herald-server/src/lib.rs
@@ -2,9 +2,9 @@ pub mod api;
 pub mod db;
 pub mod state;
 
+use axum::Router;
 use axum::middleware;
 use axum::routing::{delete, get, post, put};
-use axum::Router;
 
 use state::AppState;
 

--- a/crates/herald-server/src/main.rs
+++ b/crates/herald-server/src/main.rs
@@ -45,7 +45,5 @@ async fn main() {
 
     tracing::info!("Herald server listening on port {port}");
 
-    axum::serve(listener, app)
-        .await
-        .expect("server error");
+    axum::serve(listener, app).await.expect("server error");
 }

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -2,7 +2,7 @@ use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
 use herald_server::{build_router, db, state::AppState};
 use http_body_util::BodyExt;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tower::ServiceExt;
 
 const TEST_TOKEN: &str = "test-secret-token";
@@ -572,7 +572,10 @@ async fn config_get_returns_defaults() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let config = json_body(response).await;
-    assert!(config["rotation_interval_seconds"].is_string() || config["rotation_interval_seconds"].is_number());
+    assert!(
+        config["rotation_interval_seconds"].is_string()
+            || config["rotation_interval_seconds"].is_number()
+    );
     assert!(config["default_h_align"].is_string());
 
     cleanup(&db_path);


### PR DESCRIPTION
## Summary

Bootstraps the Herald server as a Cargo workspace with two crates and a full REST API backed by SQLite.

### What's included

- **Cargo workspace** with \herald-common\ (shared types) and \herald-server\ (Axum web server)
- **Shared types** — domain models for messages, countdowns, queue, config, and API error responses
- **REST API** (Axum 0.8) with endpoints for:
  - \/health\ — health check (no auth)
  - \/api/messages\ — CRUD for overlay messages
  - \/api/countdowns\ — CRUD for countdown timers
  - \/api/queue\ — display-queue management with reorder
  - \/api/config\ — runtime config read/update
- **Bearer-token auth** middleware on all \/api/*\ routes
- **SQLite persistence** via sqlx with an init migration
- **17 integration tests** covering happy paths, validation, auth rejection, and edge cases
- **Architecture and spec docs** updated to reflect implementation

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] \cargo test\ passes (17/17)
- [x] I have added tests for new functionality
- [x] I have updated documentation