### PR TITLE
feat: implement WebSocket upgrade endpoint (/ws)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -78,8 +79,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -254,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +456,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -466,13 +487,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -525,6 +558,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "futures-util",
  "herald-common",
  "http-body-util",
  "serde",
@@ -532,6 +566,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tower",
  "tower-http",
  "tracing",
@@ -952,7 +987,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1124,6 +1159,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1135,8 +1176,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1146,7 +1197,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1156,6 +1217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1206,7 +1276,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1357,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1521,7 +1591,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -1561,7 +1631,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -1745,6 +1815,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,6 +1958,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +2040,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["full"] }
 
 # Web framework
-axum = { version = "0.8", features = ["json"] }
+axum = { version = "0.8", features = ["json", "ws"] }
 tower = { version = "0.5" }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
+tokio-tungstenite = "0.26"
+futures-util = "0.3"
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid"] }

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -183,6 +183,53 @@ impl Default for BoardState {
     }
 }
 
+// ── WebSocket protocol ───────────────────────────────────────────
+
+/// Messages sent from the server to connected viewers over WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ServerMessage {
+    /// Full board state — sent on initial connection and on every board change.
+    #[serde(rename = "board_update")]
+    BoardUpdate(BoardState),
+
+    /// Heartbeat — server sends periodically to keep the connection alive.
+    #[serde(rename = "heartbeat")]
+    Heartbeat {
+        server_time: DateTime<Utc>,
+    },
+
+    /// Queue metadata — sent alongside board_update for status bar rendering.
+    #[serde(rename = "queue_info")]
+    QueueInfo {
+        current_index: usize,
+        total_items: usize,
+        next_rotation_seconds: u32,
+        is_countdown_active: bool,
+    },
+
+    /// Server is shutting down — clients should expect disconnection.
+    #[serde(rename = "shutdown")]
+    Shutdown {
+        reason: String,
+    },
+
+    /// Error notification.
+    #[serde(rename = "error")]
+    Error {
+        message: String,
+    },
+}
+
+/// Messages sent from a viewer client to the server over WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ClientMessage {
+    /// Response to a heartbeat.
+    #[serde(rename = "pong")]
+    Pong,
+}
+
 // ── API request/response DTOs ─────────────────────────────────────
 
 /// Request body for POST /api/messages.

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -195,9 +195,7 @@ pub enum ServerMessage {
 
     /// Heartbeat — server sends periodically to keep the connection alive.
     #[serde(rename = "heartbeat")]
-    Heartbeat {
-        server_time: DateTime<Utc>,
-    },
+    Heartbeat { server_time: DateTime<Utc> },
 
     /// Queue metadata — sent alongside board_update for status bar rendering.
     #[serde(rename = "queue_info")]
@@ -210,15 +208,11 @@ pub enum ServerMessage {
 
     /// Server is shutting down — clients should expect disconnection.
     #[serde(rename = "shutdown")]
-    Shutdown {
-        reason: String,
-    },
+    Shutdown { reason: String },
 
     /// Error notification.
     #[serde(rename = "error")]
-    Error {
-        message: String,
-    },
+    Error { message: String },
 }
 
 /// Messages sent from a viewer client to the server over WebSocket.

--- a/crates/herald-server/Cargo.toml
+++ b/crates/herald-server/Cargo.toml
@@ -23,3 +23,5 @@ thiserror = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
+tokio-tungstenite = { workspace = true }
+futures-util = { workspace = true }

--- a/crates/herald-server/src/lib.rs
+++ b/crates/herald-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod db;
 pub mod state;
+pub mod ws;
 
 use axum::Router;
 use axum::middleware;
@@ -40,5 +41,6 @@ pub fn build_router(state: AppState) -> Router {
     Router::new()
         .nest("/api", admin_api)
         .nest("/api", public_api)
+        .route("/ws", get(ws::ws_upgrade))
         .with_state(state)
 }

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use herald_common::ServerMessage;

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -1,7 +1,12 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
+use herald_common::ServerMessage;
 use sqlx::SqlitePool;
+use tokio::sync::broadcast;
+
+const BROADCAST_CAPACITY: usize = 16;
 
 /// Shared application state, wrapped in Arc for cheap cloning.
 #[derive(Clone)]
@@ -13,15 +18,20 @@ struct InnerState {
     pub pool: SqlitePool,
     pub admin_token: String,
     pub started_at: Instant,
+    pub broadcast_tx: broadcast::Sender<ServerMessage>,
+    pub viewer_count: AtomicUsize,
 }
 
 impl AppState {
     pub fn new(pool: SqlitePool, admin_token: String) -> Self {
+        let (broadcast_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(InnerState {
                 pool,
                 admin_token,
                 started_at: Instant::now(),
+                broadcast_tx,
+                viewer_count: AtomicUsize::new(0),
             }),
         }
     }
@@ -36,5 +46,30 @@ impl AppState {
 
     pub fn uptime_seconds(&self) -> u64 {
         self.inner.started_at.elapsed().as_secs()
+    }
+
+    /// Get a reference to the broadcast sender (for sending board updates).
+    pub fn broadcast_tx(&self) -> &broadcast::Sender<ServerMessage> {
+        &self.inner.broadcast_tx
+    }
+
+    /// Subscribe to the broadcast channel (for new WS connections).
+    pub fn subscribe_broadcast(&self) -> broadcast::Receiver<ServerMessage> {
+        self.inner.broadcast_tx.subscribe()
+    }
+
+    /// Increment viewer count and return the new count.
+    pub fn add_viewer(&self) -> usize {
+        self.inner.viewer_count.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Decrement viewer count and return the new count.
+    pub fn remove_viewer(&self) -> usize {
+        self.inner.viewer_count.fetch_sub(1, Ordering::Relaxed) - 1
+    }
+
+    /// Get the current viewer count.
+    pub fn viewer_count(&self) -> usize {
+        self.inner.viewer_count.load(Ordering::Relaxed)
     }
 }

--- a/crates/herald-server/src/ws.rs
+++ b/crates/herald-server/src/ws.rs
@@ -1,0 +1,66 @@
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
+use axum::response::IntoResponse;
+use tokio::sync::broadcast;
+
+use crate::state::AppState;
+
+/// Handle WebSocket upgrade request.
+/// This endpoint is unauthenticated — any viewer can connect.
+pub async fn ws_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_connection(socket, state))
+}
+
+/// Manage a single WebSocket connection lifecycle.
+async fn handle_connection(mut socket: WebSocket, state: AppState) {
+    let viewer_count = state.add_viewer();
+    tracing::info!("WebSocket client connected (viewers: {viewer_count})");
+
+    let mut broadcast_rx = state.subscribe_broadcast();
+
+    loop {
+        tokio::select! {
+            // Forward broadcast messages to this client
+            msg = broadcast_rx.recv() => {
+                match msg {
+                    Ok(server_msg) => {
+                        match serde_json::to_string(&server_msg) {
+                            Ok(text) => {
+                                if socket.send(Message::Text(text.into())).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => tracing::error!("Serialize error: {e}"),
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!("Viewer lagged, skipped {n} messages");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            // Process incoming client messages
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Ok(herald_common::ClientMessage::Pong) = serde_json::from_str(&text) {
+                            tracing::trace!("Received pong from viewer");
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Err(e)) => {
+                        tracing::debug!("WebSocket receive error: {e}");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let viewer_count = state.remove_viewer();
+    tracing::info!("WebSocket client disconnected (viewers: {viewer_count})");
+}

--- a/crates/herald-server/src/ws.rs
+++ b/crates/herald-server/src/ws.rs
@@ -1,5 +1,5 @@
-use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use tokio::sync::broadcast;
 
@@ -7,10 +7,7 @@ use crate::state::AppState;
 
 /// Handle WebSocket upgrade request.
 /// This endpoint is unauthenticated — any viewer can connect.
-pub async fn ws_upgrade(
-    ws: WebSocketUpgrade,
-    State(state): State<AppState>,
-) -> impl IntoResponse {
+pub async fn ws_upgrade(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     ws.on_upgrade(move |socket| handle_connection(socket, state))
 }
 

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -643,12 +643,7 @@ async fn ws_route_exists_and_is_public() {
 
     // GET /ws without upgrade headers reaches the WS handler (not auth-blocked)
     let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/ws")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/ws").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -672,8 +667,7 @@ async fn ws_upgrade_succeeds() {
 
     // Connect with a real WebSocket client
     let url = format!("ws://{addr}/ws");
-    let (ws_stream, response) =
-        tokio_tungstenite::connect_async(&url).await.unwrap();
+    let (ws_stream, response) = tokio_tungstenite::connect_async(&url).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
 
@@ -712,14 +706,11 @@ async fn ws_broadcast_delivers_message() {
     state.broadcast_tx().send(msg).unwrap();
 
     // Client should receive the message
-    let received = tokio::time::timeout(
-        std::time::Duration::from_secs(2),
-        ws_stream.next(),
-    )
-    .await
-    .expect("timeout waiting for WS message")
-    .expect("stream ended")
-    .expect("WS error");
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for WS message")
+        .expect("stream ended")
+        .expect("WS error");
 
     if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
         let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -634,3 +634,101 @@ async fn config_update_empty_returns_400() {
 
     cleanup(&db_path);
 }
+
+// ── WebSocket ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn ws_route_exists_and_is_public() {
+    let (app, db_path) = test_app().await;
+
+    // GET /ws without upgrade headers reaches the WS handler (not auth-blocked)
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/ws")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Route exists (not 404) and no auth required (not 401)
+    assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn ws_upgrade_succeeds() {
+    let (app, db_path) = test_app().await;
+
+    // Start a real TCP server so the WebSocket handshake can complete
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Connect with a real WebSocket client
+    let url = format!("ws://{addr}/ws");
+    let (ws_stream, response) =
+        tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+
+    // Clean shutdown
+    drop(ws_stream);
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn ws_broadcast_delivers_message() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Connect a WS client
+    let url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    // Broadcast a board update through the channel
+    let board_state = herald_common::BoardState::default();
+    let msg = herald_common::ServerMessage::BoardUpdate(board_state);
+    state.broadcast_tx().send(msg).unwrap();
+
+    // Client should receive the message
+    let received = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        ws_stream.next(),
+    )
+    .await
+    .expect("timeout waiting for WS message")
+    .expect("stream ended")
+    .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "board_update");
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    // Clean up the second db created by this test's state
+    cleanup(&db_path);
+}


### PR DESCRIPTION
## Description

Adds the WebSocket upgrade endpoint (`GET /ws`) to `herald-server`, enabling real-time viewer connections. This is the foundation for the Phase 2 real-time stack — broadcast, heartbeat, and CLI viewer all build on top of this.

**`herald-common` — WebSocket protocol types**
- Added `ServerMessage` enum (tagged JSON: `board_update`, `heartbeat`, `queue_info`, `shutdown`, `error`)
- Added `ClientMessage` enum (tagged JSON: `pong`)

**`herald-server` — WebSocket endpoint + broadcast infrastructure**
- `GET /ws` — unauthenticated WebSocket upgrade handler (outside `/api` prefix, no auth middleware)
- `AppState` now holds a `broadcast::Sender<ServerMessage>` (capacity 16) and an `AtomicUsize` viewer counter
- Per-connection loop uses `tokio::select!` to concurrently forward broadcast messages and process client frames
- Handles graceful disconnect, lagged consumers, and close frames

**Tests (3 new, 20 total)**
- `ws_route_exists_and_is_public` — route is reachable without auth
- `ws_upgrade_succeeds` — real TCP handshake returns 101
- `ws_broadcast_delivers_message` — end-to-end: broadcast a `BoardState`, verify client receives JSON with `"type": "board_update"`

**Dependencies added**
- `axum` `ws` feature enabled
- `tokio-tungstenite` + `futures-util` (workspace dev-dependencies for tests)

## Related Issues

Closes #11

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)