### PR TITLE
 feat: broadcast board updates to WebSocket viewers on content mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Health check endpoint (unauthenticated) returning status, version, and uptime
 - 17 integration tests covering all API endpoints and error cases
 - CLI binary (`herald`) with subcommands: serve, watch, push, countdown, queue, config
+- Real-time board update broadcasts to WebSocket viewers on every content mutation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +401,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -496,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,10 +586,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -695,6 +751,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,7 +803,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herald-cli"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -743,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "herald-common"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",
@@ -753,13 +828,14 @@ dependencies = [
 
 [[package]]
 name = "herald-server"
-version = "0.1.1"
+version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
  "futures-util",
  "herald-common",
  "http-body-util",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",
@@ -861,6 +937,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -869,6 +946,38 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -877,13 +986,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1060,6 +1179,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1221,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1145,6 +1282,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1226,6 +1369,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1451,50 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -1555,6 +1759,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,8 +1841,54 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1600,10 +1904,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2068,6 +2404,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2078,6 +2417,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2163,6 +2536,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2591,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,9 +2627,12 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
+ "iri-string",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2315,6 +2724,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -2418,6 +2833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,6 +2899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2948,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2584,6 +3024,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2660,6 +3110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +3145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/herald-server/Cargo.toml
+++ b/crates/herald-server/Cargo.toml
@@ -25,3 +25,5 @@ tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
 tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }
+reqwest = { version = "0.12", features = ["json"] }
+chrono = { workspace = true }

--- a/crates/herald-server/src/api/countdowns.rs
+++ b/crates/herald-server/src/api/countdowns.rs
@@ -40,6 +40,7 @@ pub async fn create(
     };
 
     db::create_countdown(state.pool(), &cd).await?;
+    state.notify_board_update().await;
 
     Ok((StatusCode::CREATED, Json(cd)))
 }
@@ -81,6 +82,8 @@ pub async fn update(
         .await?
         .ok_or_else(|| ApiError::Internal("countdown disappeared after update".to_string()))?;
 
+    state.notify_board_update().await;
+
     Ok(Json(cd))
 }
 
@@ -92,5 +95,6 @@ pub async fn delete(
     if !deleted {
         return Err(ApiError::NotFound(format!("countdown {id} not found")));
     }
+    state.notify_board_update().await;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -33,6 +33,7 @@ pub async fn create(
     };
 
     db::create_message(state.pool(), &msg).await?;
+    state.notify_board_update().await;
 
     Ok((StatusCode::CREATED, Json(msg)))
 }
@@ -75,6 +76,8 @@ pub async fn update(
         .await?
         .ok_or_else(|| ApiError::Internal("message disappeared after update".to_string()))?;
 
+    state.notify_board_update().await;
+
     Ok(Json(msg))
 }
 
@@ -86,5 +89,6 @@ pub async fn delete(
     if !deleted {
         return Err(ApiError::NotFound(format!("message {id} not found")));
     }
+    state.notify_board_update().await;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/herald-server/src/api/queue.rs
+++ b/crates/herald-server/src/api/queue.rs
@@ -35,6 +35,7 @@ pub async fn reorder(
     }
 
     db::reorder_queue(state.pool(), &req.order).await?;
+    state.notify_board_update().await;
 
     // Return the updated queue
     let items = db::get_queue(state.pool()).await?;

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -489,12 +489,10 @@ pub async fn build_board_state(pool: &SqlitePool) -> Result<BoardState, sqlx::Er
     let current_item = &queue[idx];
 
     let grid = match current_item.kind {
-        QueueItemKind::Message => {
-            match get_message(pool, &current_item.id.to_string()).await? {
-                Some(msg) => msg.grid,
-                None => Grid::blank(),
-            }
-        }
+        QueueItemKind::Message => match get_message(pool, &current_item.id.to_string()).await? {
+            Some(msg) => msg.grid,
+            None => Grid::blank(),
+        },
         QueueItemKind::Countdown => {
             // Countdown grid rendering is not yet implemented;
             // broadcast a blank grid so viewers still get the metadata.

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -475,3 +475,43 @@ pub async fn queue_size(pool: &SqlitePool) -> Result<usize, sqlx::Error> {
     let total: i64 = row.get("total");
     Ok(total as usize)
 }
+
+/// Build the current board state from the queue and rotation state.
+pub async fn build_board_state(pool: &SqlitePool) -> Result<BoardState, sqlx::Error> {
+    let queue = get_queue(pool).await?;
+    let current_idx = get_current_index(pool).await?;
+
+    if queue.is_empty() {
+        return Ok(BoardState::default());
+    }
+
+    let idx = (current_idx as usize) % queue.len();
+    let current_item = &queue[idx];
+
+    let grid = match current_item.kind {
+        QueueItemKind::Message => {
+            match get_message(pool, &current_item.id.to_string()).await? {
+                Some(msg) => msg.grid,
+                None => Grid::blank(),
+            }
+        }
+        QueueItemKind::Countdown => {
+            // Countdown grid rendering is not yet implemented;
+            // broadcast a blank grid so viewers still get the metadata.
+            Grid::blank()
+        }
+    };
+
+    let item_info = QueueItemInfo {
+        id: current_item.id,
+        kind: current_item.kind,
+        label: current_item.label.clone(),
+    };
+
+    Ok(BoardState {
+        grid,
+        previous_grid: Grid::blank(),
+        current_item: Some(item_info),
+        timestamp: chrono::Utc::now(),
+    })
+}

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
-use herald_common::ServerMessage;
+use herald_common::{Grid, ServerMessage};
 use sqlx::SqlitePool;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast};
 
 const BROADCAST_CAPACITY: usize = 16;
 
@@ -20,6 +20,9 @@ struct InnerState {
     pub started_at: Instant,
     pub broadcast_tx: broadcast::Sender<ServerMessage>,
     pub viewer_count: AtomicUsize,
+    /// Guards the build-board-state → broadcast path so concurrent mutations
+    /// cannot interleave and produce out-of-order previous_grid values.
+    pub notify_lock: Mutex<Grid>,
 }
 
 impl AppState {
@@ -32,6 +35,7 @@ impl AppState {
                 started_at: Instant::now(),
                 broadcast_tx,
                 viewer_count: AtomicUsize::new(0),
+                notify_lock: Mutex::new(Grid::blank()),
             }),
         }
     }
@@ -71,5 +75,28 @@ impl AppState {
     /// Get the current viewer count.
     pub fn viewer_count(&self) -> usize {
         self.inner.viewer_count.load(Ordering::Relaxed)
+    }
+
+    /// Build the current board state from the database and broadcast it to all connected viewers.
+    /// The entire build → broadcast path is serialized via a Mutex so concurrent
+    /// mutations cannot produce out-of-order `previous_grid` values.
+    pub async fn notify_board_update(&self) {
+        let mut last_grid = self.inner.notify_lock.lock().await;
+
+        match crate::db::build_board_state(self.pool()).await {
+            Ok(mut board_state) => {
+                board_state.previous_grid = last_grid.clone();
+                *last_grid = board_state.grid.clone();
+                drop(last_grid);
+
+                let _ = self.inner.broadcast_tx.send(
+                    herald_common::ServerMessage::BoardUpdate(board_state),
+                );
+            }
+            Err(e) => {
+                drop(last_grid);
+                tracing::error!("Failed to build board state for broadcast: {e}");
+            }
+        }
     }
 }

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -89,9 +89,10 @@ impl AppState {
                 *last_grid = board_state.grid.clone();
                 drop(last_grid);
 
-                let _ = self.inner.broadcast_tx.send(
-                    herald_common::ServerMessage::BoardUpdate(board_state),
-                );
+                let _ = self
+                    .inner
+                    .broadcast_tx
+                    .send(herald_common::ServerMessage::BoardUpdate(board_state));
             }
             Err(e) => {
                 drop(last_grid);

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -723,3 +723,194 @@ async fn ws_broadcast_delivers_message() {
     // Clean up the second db created by this test's state
     cleanup(&db_path);
 }
+
+// ── WS broadcast integration tests ──────────────────────────────
+
+#[tokio::test]
+async fn ws_broadcast_on_message_create() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Connect a WS client
+    let ws_url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // Create a message via HTTP
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/messages"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "grid": text_grid("BROADCAST"),
+            "h_align": "center",
+            "v_align": "middle"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // WS client should receive a board_update
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for broadcast")
+        .expect("stream ended")
+        .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "board_update");
+        assert!(parsed["grid"].is_array());
+        assert!(parsed["current_item"].is_object());
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn ws_broadcast_on_message_delete() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let ws_url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // Create a message
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/messages"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "grid": text_grid("DELETE ME"),
+            "h_align": "center",
+            "v_align": "middle"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    let msg: serde_json::Value = resp.json().await.unwrap();
+    let msg_id = msg["id"].as_str().unwrap().to_string();
+
+    // Drain the create broadcast
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next()).await;
+
+    // Delete the message
+    let resp = client
+        .delete(format!("http://{addr}/api/messages/{msg_id}"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NO_CONTENT);
+
+    // WS client should receive a board_update with empty board
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for delete broadcast")
+        .expect("stream ended")
+        .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "board_update");
+        // Queue is now empty, so current_item should be null
+        assert!(parsed["current_item"].is_null());
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn ws_broadcast_on_countdown_create() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let ws_url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // Create a countdown via HTTP
+    let client = reqwest::Client::new();
+    let future_time = chrono::Utc::now() + chrono::Duration::hours(1);
+    let resp = client
+        .post(format!("http://{addr}/api/countdowns"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "label": "Launch",
+            "target": future_time.to_rfc3339()
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // WS client should receive a board_update
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for broadcast")
+        .expect("stream ended")
+        .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["type"], "board_update");
+        assert_eq!(parsed["current_item"]["kind"], "countdown");
+        assert_eq!(parsed["current_item"]["label"], "Launch");
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    cleanup(&db_path);
+}


### PR DESCRIPTION
## Description

Add real-time board update broadcasting to all connected WebSocket viewers whenever board content changes.

### What's included

- **Broadcast on mutation**: Every admin write operation (create/update/delete on messages, countdowns, and queue reorder) now triggers a board_update WebSocket broadcast to all connected viewers.
- **Board state builder**: New build_board_state function in the db module assembles the current grid, queue position, and item metadata into a BoardState snapshot.
- **Serialized notify path**: A Mutex-guarded notify path in AppState ensures concurrent mutations produce correct previous_grid values without interleaving.
- **Integration tests**: Three new tests (ws_broadcast_on_message_create, ws_broadcast_on_message_delete, ws_broadcast_on_countdown_create) verify end-to-end broadcast delivery through real HTTP + WebSocket connections.

## Related Issues

Closes #12 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [ ] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)