### PR TITLE
feat: send initial board state on WebSocket connect and add CLI WebSocket client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/herald-cli/Cargo.toml
+++ b/crates/herald-cli/Cargo.toml
@@ -19,3 +19,4 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 futures-util = { workspace = true }
+tracing = { workspace = true }

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -1,4 +1,24 @@
-pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    eprintln!("watch is not yet implemented");
+use crate::ws_client::WsClient;
+
+pub async fn run(server: String) -> Result<(), Box<dyn std::error::Error>> {
+    let (client, mut board_rx) = WsClient::new(server);
+
+    // Spawn the WS client in a background task
+    tokio::spawn(async move {
+        client.run().await;
+    });
+
+    // Consume board state updates (placeholder for future TUI rendering)
+    loop {
+        if board_rx.changed().await.is_err() {
+            break;
+        }
+        let state = board_rx.borrow().clone();
+        eprintln!(
+            "Board updated: current_item={:?}, timestamp={}",
+            state.current_item, state.timestamp
+        );
+    }
+
     Ok(())
 }

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod ws_client;
 
 use clap::{Parser, Subcommand};
 
@@ -15,7 +16,11 @@ enum Command {
     /// Start the Herald server
     Serve,
     /// Watch the board in your terminal
-    Watch,
+    Watch {
+        /// WebSocket server URL
+        #[arg(long, default_value = "ws://localhost:3000/ws")]
+        server: String,
+    },
     /// Push a message to the board
     Push,
     /// Manage countdowns
@@ -31,7 +36,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Watch => commands::watch::run().await,
+        Command::Watch { server } => commands::watch::run(server).await,
         Command::Serve => {
             eprintln!("serve is not yet implemented");
             Ok(())

--- a/crates/herald-cli/src/ws_client.rs
+++ b/crates/herald-cli/src/ws_client.rs
@@ -27,11 +27,17 @@ impl WsClient {
 
     /// Run the connection loop. Connects to the server, receives messages,
     /// and reconnects with exponential backoff on disconnection.
-    /// This runs forever and should be spawned as a tokio task.
+    /// Stops automatically when all watch receivers are dropped.
+    /// Should be spawned as a tokio task.
     pub async fn run(&self) {
         let mut backoff_secs = INITIAL_BACKOFF_SECS;
 
         loop {
+            if self.board_tx.is_closed() {
+                tracing::info!("All receivers dropped, stopping WS client");
+                return;
+            }
+
             match tokio_tungstenite::connect_async(&self.server_url).await {
                 Ok((ws_stream, _)) => {
                     tracing::info!("Connected to {}", self.server_url);
@@ -44,7 +50,12 @@ impl WsClient {
                             Some(Ok(Message::Text(text))) => {
                                 match serde_json::from_str::<ServerMessage>(&text) {
                                     Ok(ServerMessage::BoardUpdate(board_state)) => {
-                                        let _ = self.board_tx.send(board_state);
+                                        if self.board_tx.send(board_state).is_err() {
+                                            tracing::info!(
+                                                "All receivers dropped, stopping WS client"
+                                            );
+                                            return;
+                                        }
                                     }
                                     Ok(_other) => {
                                         tracing::trace!("Received non-board message, skipping");
@@ -63,10 +74,7 @@ impl WsClient {
                                 }
                             }
                             Some(Ok(Message::Close(_))) => {
-                                tracing::info!(
-                                    "Server closed connection to {}",
-                                    self.server_url
-                                );
+                                tracing::info!("Server closed connection to {}", self.server_url);
                                 break;
                             }
                             Some(Ok(_)) => {
@@ -77,10 +85,7 @@ impl WsClient {
                                 break;
                             }
                             None => {
-                                tracing::info!(
-                                    "WebSocket stream ended for {}",
-                                    self.server_url
-                                );
+                                tracing::info!("WebSocket stream ended for {}", self.server_url);
                                 break;
                             }
                         }
@@ -93,10 +98,13 @@ impl WsClient {
                     );
                     tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                     backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
+                    continue;
                 }
             }
 
-            // Brief pause before reconnecting after a clean disconnect
+            // Brief pause before reconnecting after a clean disconnect.
+            // Only reached after a successful connection that later disconnected.
+            // The `continue` in the Err branch skips this to avoid double-sleeping.
             tokio::time::sleep(Duration::from_secs(INITIAL_BACKOFF_SECS)).await;
         }
     }

--- a/crates/herald-cli/src/ws_client.rs
+++ b/crates/herald-cli/src/ws_client.rs
@@ -1,0 +1,103 @@
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use herald_common::{BoardState, ServerMessage};
+use tokio::sync::watch;
+use tokio_tungstenite::tungstenite::Message;
+
+const INITIAL_BACKOFF_SECS: u64 = 1;
+const MAX_BACKOFF_SECS: u64 = 30;
+
+pub struct WsClient {
+    server_url: String,
+    board_tx: watch::Sender<BoardState>,
+}
+
+impl WsClient {
+    /// Create a new WsClient and return it along with a watch::Receiver
+    /// that will be updated whenever a new BoardState arrives from the server.
+    pub fn new(server_url: String) -> (Self, watch::Receiver<BoardState>) {
+        let (board_tx, board_rx) = watch::channel(BoardState::default());
+        let client = Self {
+            server_url,
+            board_tx,
+        };
+        (client, board_rx)
+    }
+
+    /// Run the connection loop. Connects to the server, receives messages,
+    /// and reconnects with exponential backoff on disconnection.
+    /// This runs forever and should be spawned as a tokio task.
+    pub async fn run(&self) {
+        let mut backoff_secs = INITIAL_BACKOFF_SECS;
+
+        loop {
+            match tokio_tungstenite::connect_async(&self.server_url).await {
+                Ok((ws_stream, _)) => {
+                    tracing::info!("Connected to {}", self.server_url);
+                    backoff_secs = INITIAL_BACKOFF_SECS;
+
+                    let (mut sink, mut stream) = ws_stream.split();
+
+                    loop {
+                        match stream.next().await {
+                            Some(Ok(Message::Text(text))) => {
+                                match serde_json::from_str::<ServerMessage>(&text) {
+                                    Ok(ServerMessage::BoardUpdate(board_state)) => {
+                                        let _ = self.board_tx.send(board_state);
+                                    }
+                                    Ok(_other) => {
+                                        tracing::trace!("Received non-board message, skipping");
+                                    }
+                                    Err(err) => {
+                                        tracing::warn!(
+                                            "Failed to deserialize server message: {err}"
+                                        );
+                                    }
+                                }
+                            }
+                            Some(Ok(Message::Ping(data))) => {
+                                if let Err(err) = sink.send(Message::Pong(data)).await {
+                                    tracing::warn!("Failed to send pong: {err}");
+                                    break;
+                                }
+                            }
+                            Some(Ok(Message::Close(_))) => {
+                                tracing::info!(
+                                    "Server closed connection to {}",
+                                    self.server_url
+                                );
+                                break;
+                            }
+                            Some(Ok(_)) => {
+                                // Binary, Pong, Frame — ignore
+                            }
+                            Some(Err(err)) => {
+                                tracing::warn!("WebSocket error: {err}");
+                                break;
+                            }
+                            None => {
+                                tracing::info!(
+                                    "WebSocket stream ended for {}",
+                                    self.server_url
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "Connection to {} failed: {err}. Retrying in {backoff_secs}s...",
+                        self.server_url
+                    );
+                    tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                    backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
+                }
+            }
+
+            // Brief pause before reconnecting after a clean disconnect
+            tokio::time::sleep(Duration::from_secs(INITIAL_BACKOFF_SECS)).await;
+        }
+    }
+}

--- a/crates/herald-server/src/ws.rs
+++ b/crates/herald-server/src/ws.rs
@@ -18,6 +18,25 @@ async fn handle_connection(mut socket: WebSocket, state: AppState) {
 
     let mut broadcast_rx = state.subscribe_broadcast();
 
+    // Send the current board state as the first message so the client
+    // renders immediately without waiting for the next broadcast.
+    match crate::db::build_board_state(state.pool()).await {
+        Ok(board_state) => {
+            let msg = herald_common::ServerMessage::BoardUpdate(board_state);
+            match serde_json::to_string(&msg) {
+                Ok(text) => {
+                    if socket.send(Message::Text(text.into())).await.is_err() {
+                        let viewer_count = state.remove_viewer();
+                        tracing::info!("WebSocket client disconnected during initial state send (viewers: {viewer_count})");
+                        return;
+                    }
+                }
+                Err(e) => tracing::error!("Failed to serialize initial board state: {e}"),
+            }
+        }
+        Err(e) => tracing::warn!("Failed to build initial board state: {e}"),
+    }
+
     loop {
         tokio::select! {
             // Forward broadcast messages to this client

--- a/crates/herald-server/src/ws.rs
+++ b/crates/herald-server/src/ws.rs
@@ -27,7 +27,9 @@ async fn handle_connection(mut socket: WebSocket, state: AppState) {
                 Ok(text) => {
                     if socket.send(Message::Text(text.into())).await.is_err() {
                         let viewer_count = state.remove_viewer();
-                        tracing::info!("WebSocket client disconnected during initial state send (viewers: {viewer_count})");
+                        tracing::info!(
+                            "WebSocket client disconnected during initial state send (viewers: {viewer_count})"
+                        );
                         return;
                     }
                 }

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -963,8 +963,14 @@ async fn ws_initial_state_empty_board() {
         // Verify message format has all expected fields
         assert_eq!(parsed["type"], "board_update");
         assert!(parsed["grid"].is_array(), "missing 'grid' field");
-        assert!(parsed.get("previous_grid").is_some(), "missing 'previous_grid' field");
-        assert!(parsed.get("timestamp").is_some(), "missing 'timestamp' field");
+        assert!(
+            parsed.get("previous_grid").is_some(),
+            "missing 'previous_grid' field"
+        );
+        assert!(
+            parsed.get("timestamp").is_some(),
+            "missing 'timestamp' field"
+        );
 
         // Empty board: no queue items (field omitted by skip_serializing_if or null)
         assert!(
@@ -1040,7 +1046,10 @@ async fn ws_initial_state_with_existing_message() {
         assert!(parsed["grid"].is_array());
 
         // current_item should be populated with the message we created
-        assert!(parsed["current_item"].is_object(), "expected current_item to be populated");
+        assert!(
+            parsed["current_item"].is_object(),
+            "expected current_item to be populated"
+        );
         assert_eq!(parsed["current_item"]["kind"], "message");
 
         // Grid should contain non-blank content (the message we posted)
@@ -1053,7 +1062,10 @@ async fn ws_initial_state_with_existing_message() {
                     && cell != &serde_json::json!(null)
             })
         });
-        assert!(has_non_blank, "grid should contain the message content, not be entirely blank");
+        assert!(
+            has_non_blank,
+            "grid should contain the message content, not be entirely blank"
+        );
     } else {
         panic!("expected text message, got {:?}", received);
     }

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -750,6 +750,9 @@ async fn ws_broadcast_on_message_create() {
     let ws_url = format!("ws://{addr}/ws");
     let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
 
+    // Drain the initial board state message sent on connect
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next()).await;
+
     // Create a message via HTTP
     let client = reqwest::Client::new();
     let resp = client
@@ -765,7 +768,7 @@ async fn ws_broadcast_on_message_create() {
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
 
-    // WS client should receive a board_update
+    // WS client should receive a board_update broadcast
     let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
         .await
         .expect("timeout waiting for broadcast")
@@ -807,6 +810,9 @@ async fn ws_broadcast_on_message_delete() {
 
     let ws_url = format!("ws://{addr}/ws");
     let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // Drain the initial board state message sent on connect
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next()).await;
 
     // Create a message
     let client = reqwest::Client::new();
@@ -880,6 +886,9 @@ async fn ws_broadcast_on_countdown_create() {
     let ws_url = format!("ws://{addr}/ws");
     let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
 
+    // Drain the initial board state message sent on connect
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next()).await;
+
     // Create a countdown via HTTP
     let client = reqwest::Client::new();
     let future_time = chrono::Utc::now() + chrono::Duration::hours(1);
@@ -907,6 +916,144 @@ async fn ws_broadcast_on_countdown_create() {
         assert_eq!(parsed["type"], "board_update");
         assert_eq!(parsed["current_item"]["kind"], "countdown");
         assert_eq!(parsed["current_item"]["label"], "Launch");
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    cleanup(&db_path);
+}
+
+// ── WS initial board state tests ────────────────────────────────
+
+#[tokio::test]
+async fn ws_initial_state_empty_board() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Connect WS client to a fresh (empty) database
+    let ws_url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // First message should be the initial board state
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for initial board state")
+        .expect("stream ended")
+        .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        // Verify message format has all expected fields
+        assert_eq!(parsed["type"], "board_update");
+        assert!(parsed["grid"].is_array(), "missing 'grid' field");
+        assert!(parsed.get("previous_grid").is_some(), "missing 'previous_grid' field");
+        assert!(parsed.get("timestamp").is_some(), "missing 'timestamp' field");
+
+        // Empty board: no queue items (field omitted by skip_serializing_if or null)
+        assert!(
+            parsed.get("current_item").is_none() || parsed["current_item"].is_null(),
+            "expected current_item to be absent or null on empty board"
+        );
+
+        // Grid should be 6 rows × 22 columns of blank cells
+        let grid = parsed["grid"].as_array().unwrap();
+        assert_eq!(grid.len(), 6, "grid should have 6 rows");
+        for row in grid {
+            let cols = row.as_array().unwrap();
+            assert_eq!(cols.len(), 22, "each row should have 22 columns");
+        }
+    } else {
+        panic!("expected text message, got {:?}", received);
+    }
+
+    drop(ws_stream);
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn ws_initial_state_with_existing_message() {
+    use futures_util::StreamExt;
+
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Create a message via HTTP BEFORE connecting the WS client
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/messages"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "grid": text_grid("INITIAL"),
+            "h_align": "center",
+            "v_align": "middle"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // Now connect WS client — it should receive the current board state
+    let ws_url = format!("ws://{addr}/ws");
+    let (mut ws_stream, _) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // First message should be board_update with the existing message
+    let received = tokio::time::timeout(std::time::Duration::from_secs(2), ws_stream.next())
+        .await
+        .expect("timeout waiting for initial board state")
+        .expect("stream ended")
+        .expect("WS error");
+
+    if let tokio_tungstenite::tungstenite::Message::Text(text) = received {
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(parsed["type"], "board_update");
+        assert!(parsed["grid"].is_array());
+
+        // current_item should be populated with the message we created
+        assert!(parsed["current_item"].is_object(), "expected current_item to be populated");
+        assert_eq!(parsed["current_item"]["kind"], "message");
+
+        // Grid should contain non-blank content (the message we posted)
+        let grid = parsed["grid"].as_array().unwrap();
+        let has_non_blank = grid.iter().any(|row| {
+            row.as_array().unwrap().iter().any(|cell| {
+                // A non-blank cell is anything other than a default blank
+                cell != &serde_json::json!({"Blank": null})
+                    && cell != &serde_json::json!("Blank")
+                    && cell != &serde_json::json!(null)
+            })
+        });
+        assert!(has_non_blank, "grid should contain the message content, not be entirely blank");
     } else {
         panic!("expected text message, got {:?}", received);
     }


### PR DESCRIPTION
## Description

Send the current board state to WebSocket clients immediately on connect and add a CLI WebSocket client module with automatic reconnection.

### What's included

- **Initial board state on connect**: When a WebSocket client connects, the server now sends the current BoardState as the first message before any broadcast updates. This ensures viewers see the board immediately without waiting for the next content change. The initial message uses the same ServerMessage::BoardUpdate format as broadcasts, so clients need only one deserialization path.
- **CLI WebSocket client** (herald-cli/src/ws_client.rs): A new WsClient module connects to the server's /ws endpoint, deserializes incoming BoardState messages, and exposes them via a 	okio::sync::watch channel for the UI layer to consume. Includes automatic reconnection with exponential backoff (1s, 2s, 4s, 8s, up to 30s max). Stops cleanly when all watch receivers are dropped.
- **--server CLI argument**: The watch subcommand now accepts --server (default: ws://localhost:3000/ws) to specify the WebSocket server URL.
- **Integration tests**: Two new tests verify initial board state delivery (empty board and board with existing content). Existing broadcast tests updated to drain the initial state message.

## Related Issues

Closes #13 and #16 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)