### PR TITLE
feat: add ratatui terminal board viewer for herald watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immediate board state delivery to WebSocket clients on connect (no waiting for next update)
 - CLI WebSocket client with automatic reconnection and exponential backoff (1s–30s)
 - `--server` option on `herald watch` to specify the WebSocket server URL
+- Terminal board viewer (`herald watch`) with live-updating 6×22 grid, color tile rendering, and centered viewport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 17 integration tests covering all API endpoints and error cases
 - CLI binary (`herald`) with subcommands: serve, watch, push, countdown, queue, config
 - Real-time board update broadcasts to WebSocket viewers on every content mutation
+- Immediate board state delivery to WebSocket clients on connect (no waiting for next update)
+- CLI WebSocket client with automatic reconnection and exponential backoff (1s–30s)
+- `--server` option on `herald watch` to specify the WebSocket server URL

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -1,23 +1,76 @@
+use std::io;
+
+use crossterm::{
+    ExecutableCommand,
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::prelude::*;
+
+use crate::ui::BoardWidget;
 use crate::ws_client::WsClient;
 
 pub async fn run(server: String) -> Result<(), Box<dyn std::error::Error>> {
     let (client, mut board_rx) = WsClient::new(server);
 
-    // Spawn the WS client in a background task
     tokio::spawn(async move {
         client.run().await;
     });
 
-    // Consume board state updates (placeholder for future TUI rendering)
+    enable_raw_mode()?;
+    io::stdout().execute(EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
+
+    let result = run_tui(&mut terminal, &mut board_rx).await;
+
+    // Restore terminal — always runs even on error
+    disable_raw_mode()?;
+    io::stdout().execute(LeaveAlternateScreen)?;
+
+    result
+}
+
+async fn run_tui(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    board_rx: &mut tokio::sync::watch::Receiver<herald_common::BoardState>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Initial draw with default state
+    let board_state = board_rx.borrow().clone();
+    terminal.draw(|frame| {
+        frame.render_widget(BoardWidget::new(&board_state), frame.area());
+    })?;
+
     loop {
-        if board_rx.changed().await.is_err() {
-            break;
+        tokio::select! {
+            result = board_rx.changed() => {
+                if result.is_err() {
+                    break; // Sender dropped
+                }
+                let board_state = board_rx.borrow().clone();
+                terminal.draw(|frame| {
+                    frame.render_widget(BoardWidget::new(&board_state), frame.area());
+                })?;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {
+                if event::poll(std::time::Duration::from_millis(0))? {
+                    match event::read()? {
+                        Event::Key(key) if key.kind == KeyEventKind::Press => {
+                            match key.code {
+                                KeyCode::Char('q') | KeyCode::Esc => break,
+                                _ => {}
+                            }
+                        }
+                        Event::Resize(_, _) => {
+                            let board_state = board_rx.borrow().clone();
+                            terminal.draw(|frame| {
+                                frame.render_widget(BoardWidget::new(&board_state), frame.area());
+                            })?;
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
-        let state = board_rx.borrow().clone();
-        eprintln!(
-            "Board updated: current_item={:?}, timestamp={}",
-            state.current_item, state.timestamp
-        );
     }
 
     Ok(())

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod ui;
 mod ws_client;
 
 use clap::{Parser, Subcommand};

--- a/crates/herald-cli/src/ui/board_widget.rs
+++ b/crates/herald-cli/src/ui/board_widget.rs
@@ -1,0 +1,229 @@
+use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent, Color};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Position, Rect},
+    style::{Color as RatatuiColor, Style},
+    text::Text,
+    widgets::{Paragraph, Widget},
+};
+
+const CELL_WIDTH: u16 = 3;
+const GRID_WIDTH: u16 = BOARD_COLS as u16 * CELL_WIDTH + BOARD_COLS as u16 + 1; // 89
+const GRID_HEIGHT: u16 = BOARD_ROWS as u16 + BOARD_ROWS as u16 + 1; // 13
+
+/// Maps a Herald color to a ratatui terminal color.
+fn map_color(color: &Color) -> RatatuiColor {
+    match color {
+        Color::Red => RatatuiColor::Red,
+        Color::Orange => RatatuiColor::Rgb(255, 165, 0),
+        Color::Yellow => RatatuiColor::Yellow,
+        Color::Green => RatatuiColor::Green,
+        Color::Blue => RatatuiColor::Blue,
+        Color::Violet => RatatuiColor::Magenta,
+        Color::White => RatatuiColor::White,
+        Color::Black => RatatuiColor::Black,
+    }
+}
+
+/// A ratatui widget that renders the Herald 6×22 board grid with box-drawing borders.
+pub struct BoardWidget<'a> {
+    board_state: &'a BoardState,
+}
+
+impl<'a> BoardWidget<'a> {
+    pub fn new(board_state: &'a BoardState) -> Self {
+        Self { board_state }
+    }
+}
+
+impl<'a> Widget for BoardWidget<'a> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Show a warning if the terminal is too small.
+        if area.width < GRID_WIDTH || area.height < GRID_HEIGHT {
+            let msg = format!(
+                "Terminal too small (need {}×{}, have {}×{})",
+                GRID_WIDTH, GRID_HEIGHT, area.width, area.height
+            );
+            let paragraph = Paragraph::new(Text::raw(msg)).alignment(Alignment::Center);
+            // Vertically center the single-line warning.
+            let y_off = area.height.saturating_sub(1) / 2;
+            let warning_area = Rect::new(area.x, area.y + y_off, area.width, 1);
+            paragraph.render(warning_area, buf);
+            return;
+        }
+
+        let x_offset = area.x + (area.width.saturating_sub(GRID_WIDTH)) / 2;
+        let y_offset = area.y + (area.height.saturating_sub(GRID_HEIGHT)) / 2;
+
+        // ── Draw horizontal border rows ──────────────────────────────
+        for row in 0..=BOARD_ROWS as u16 {
+            let y = y_offset + row * 2;
+            for col in 0..=BOARD_COLS as u16 {
+                let x = x_offset + col * (CELL_WIDTH + 1);
+
+                // Junction character
+                let junction = match (row, col) {
+                    (0, 0) => '┌',
+                    (0, c) if c == BOARD_COLS as u16 => '┐',
+                    (r, 0) if r == BOARD_ROWS as u16 => '└',
+                    (r, c) if r == BOARD_ROWS as u16 && c == BOARD_COLS as u16 => '┘',
+                    (0, _) => '┬',
+                    (r, _) if r == BOARD_ROWS as u16 => '┴',
+                    (_, 0) => '├',
+                    (_, c) if c == BOARD_COLS as u16 => '┤',
+                    _ => '┼',
+                };
+
+                if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+                    cell.set_char(junction);
+                }
+
+                // Horizontal dashes after the junction (except at last column)
+                if col < BOARD_COLS as u16 {
+                    for dx in 1..=CELL_WIDTH {
+                        if let Some(cell) = buf.cell_mut(Position::new(x + dx, y)) {
+                            cell.set_char('─');
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Draw content rows ────────────────────────────────────────
+        for row in 0..BOARD_ROWS as u16 {
+            let y = y_offset + row * 2 + 1;
+
+            // Vertical borders (including right-most)
+            for col in 0..=BOARD_COLS as u16 {
+                let x = x_offset + col * (CELL_WIDTH + 1);
+                if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+                    cell.set_char('│');
+                }
+            }
+
+            // Cell content
+            for col in 0..BOARD_COLS as u16 {
+                let x_start = x_offset + col * (CELL_WIDTH + 1) + 1;
+                let content = &self.board_state.grid.0[row as usize][col as usize];
+
+                match content {
+                    CellContent::Char(c) => {
+                        // " c " — character centered in 3 cells
+                        let chars = [' ', *c, ' '];
+                        for (dx, ch) in chars.iter().enumerate() {
+                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx as u16, y))
+                            {
+                                cell.set_char(*ch);
+                            }
+                        }
+                    }
+                    CellContent::Color(color) => {
+                        let style = Style::default().bg(map_color(color));
+                        for dx in 0..CELL_WIDTH {
+                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
+                                cell.set_char(' ').set_style(style);
+                            }
+                        }
+                    }
+                    CellContent::Blank => {
+                        for dx in 0..CELL_WIDTH {
+                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
+                                cell.set_char(' ');
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    fn blank_board() -> BoardState {
+        BoardState::default()
+    }
+
+    #[test]
+    fn too_small_shows_warning() {
+        let state = blank_board();
+        let widget = BoardWidget::new(&state);
+        let area = Rect::new(0, 0, 40, 5);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+        let text: String = (0..area.width)
+            .map(|x| {
+                buf.cell(Position::new(x, 2))
+                    .unwrap()
+                    .symbol()
+                    .chars()
+                    .next()
+                    .unwrap_or(' ')
+            })
+            .collect();
+        assert!(text.contains("Terminal too small"));
+    }
+
+    #[test]
+    fn renders_corners() {
+        let state = blank_board();
+        let widget = BoardWidget::new(&state);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        // Top-left corner
+        assert_eq!(buf.cell(Position::new(0, 0)).unwrap().symbol(), "┌");
+        // Top-right corner
+        assert_eq!(
+            buf.cell(Position::new(GRID_WIDTH - 1, 0)).unwrap().symbol(),
+            "┐"
+        );
+        // Bottom-left corner
+        assert_eq!(
+            buf.cell(Position::new(0, GRID_HEIGHT - 1))
+                .unwrap()
+                .symbol(),
+            "└"
+        );
+        // Bottom-right corner
+        assert_eq!(
+            buf.cell(Position::new(GRID_WIDTH - 1, GRID_HEIGHT - 1))
+                .unwrap()
+                .symbol(),
+            "┘"
+        );
+    }
+
+    #[test]
+    fn renders_char_cell() {
+        let mut state = blank_board();
+        state.grid.0[0][0] = CellContent::Char('H');
+        let widget = BoardWidget::new(&state);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        // Cell (0,0) content starts at x=1, y=1
+        assert_eq!(buf.cell(Position::new(1, 1)).unwrap().symbol(), " ");
+        assert_eq!(buf.cell(Position::new(2, 1)).unwrap().symbol(), "H");
+        assert_eq!(buf.cell(Position::new(3, 1)).unwrap().symbol(), " ");
+    }
+
+    #[test]
+    fn renders_color_cell_background() {
+        let mut state = blank_board();
+        state.grid.0[0][0] = CellContent::Color(Color::Red);
+        let widget = BoardWidget::new(&state);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let cell = buf.cell(Position::new(1, 1)).unwrap();
+        assert_eq!(cell.bg, RatatuiColor::Red);
+    }
+}

--- a/crates/herald-cli/src/ui/mod.rs
+++ b/crates/herald-cli/src/ui/mod.rs
@@ -1,0 +1,3 @@
+mod board_widget;
+
+pub use board_widget::BoardWidget;


### PR DESCRIPTION
## Description

Add a ratatui terminal UI for the herald watch command that renders the 6×22 board grid in real time.

### What's included

- **Board grid widget**: A custom ratatui BoardWidget renders the 6×22 grid using Unicode box-drawing characters (┌─┬┐│├┼┤└─┴┘). Each cell is a 3-character-wide tile displaying characters centered, solid color blocks via terminal background colors, or blank spaces.
- **Color mapping**: Herald's Color enum maps to ANSI terminal colors (Red, Yellow, Green, Blue, Magenta, White, Black) with RGB fallback for Orange.
- **Centered viewport**: The grid is automatically centered in the terminal viewport regardless of window size.
- **Minimum size warning**: When the terminal is smaller than the required 89×13 characters, a helpful warning message is displayed instead of a broken layout.
- **Live TUI event loop**: The watch command now enters a full-screen alternate terminal with:
  - Instant grid redraws when a new BoardState arrives via WebSocket
  - Keyboard handling: q or Esc to quit
  - Terminal resize handling with automatic redraw
  - Guaranteed terminal cleanup on exit (raw mode and alternate screen restored)
- **Unit tests**: Four tests verify corner rendering, character cell display, color background rendering, and the too-small warning fallback.

## Related Issues

Closes #17 
Closed #16 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)