### PR TITLE
feat: add terminal board viewer with status bar and connection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI WebSocket client with automatic reconnection and exponential backoff (1s–30s)
 - `--server` option on `herald watch` to specify the WebSocket server URL
 - Terminal board viewer (`herald watch`) with live-updating 6×22 grid, color tile rendering, and centered viewport
+- Connection status bar showing state (Connected/Connecting/Reconnecting/Disconnected), server URL, and time since last update
+- `--fps` option on `herald watch` to control UI refresh rate (default 30)

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -2,8 +2,7 @@ use std::io;
 use std::time::{Duration, Instant};
 
 use crossterm::{
-    ExecutableCommand,
-    cursor,
+    ExecutableCommand, cursor,
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -50,14 +49,13 @@ async fn run_tui(
                 server_url: &str,
                 last_update: Option<Instant>| {
         let area = frame.area();
-        let chunks = Layout::vertical([
-            Constraint::Min(0),
-            Constraint::Length(1),
-        ])
-        .split(area);
+        let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
         frame.render_widget(BoardWidget::new(board_state), chunks[0]);
-        frame.render_widget(StatusBar::new(conn_state, server_url, last_update), chunks[1]);
+        frame.render_widget(
+            StatusBar::new(conn_state, server_url, last_update),
+            chunks[1],
+        );
     };
 
     // Initial draw

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -1,17 +1,19 @@
 use std::io;
+use std::time::{Duration, Instant};
 
 use crossterm::{
     ExecutableCommand,
-    event::{self, Event, KeyCode, KeyEventKind},
+    cursor,
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::prelude::*;
 
-use crate::ui::BoardWidget;
+use crate::ui::{BoardWidget, StatusBar};
 use crate::ws_client::WsClient;
 
-pub async fn run(server: String) -> Result<(), Box<dyn std::error::Error>> {
-    let (client, mut board_rx) = WsClient::new(server);
+pub async fn run(server: String, fps: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let (client, mut board_rx, mut conn_rx) = WsClient::new(server.clone());
 
     tokio::spawn(async move {
         client.run().await;
@@ -19,12 +21,14 @@ pub async fn run(server: String) -> Result<(), Box<dyn std::error::Error>> {
 
     enable_raw_mode()?;
     io::stdout().execute(EnterAlternateScreen)?;
+    io::stdout().execute(cursor::Hide)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
 
-    let result = run_tui(&mut terminal, &mut board_rx).await;
+    let result = run_tui(&mut terminal, &mut board_rx, &mut conn_rx, &server, fps).await;
 
     // Restore terminal — always runs even on error
     disable_raw_mode()?;
+    io::stdout().execute(cursor::Show)?;
     io::stdout().execute(LeaveAlternateScreen)?;
 
     result
@@ -33,38 +37,75 @@ pub async fn run(server: String) -> Result<(), Box<dyn std::error::Error>> {
 async fn run_tui(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     board_rx: &mut tokio::sync::watch::Receiver<herald_common::BoardState>,
+    conn_rx: &mut tokio::sync::watch::Receiver<crate::ws_client::ConnectionState>,
+    server_url: &str,
+    fps: u16,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Initial draw with default state
+    let tick_duration = Duration::from_millis(1000 / fps.max(1) as u64);
+    let mut last_update: Option<Instant> = None;
+
+    let draw = |frame: &mut ratatui::Frame,
+                board_state: &herald_common::BoardState,
+                conn_state: &crate::ws_client::ConnectionState,
+                server_url: &str,
+                last_update: Option<Instant>| {
+        let area = frame.area();
+        let chunks = Layout::vertical([
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+        frame.render_widget(BoardWidget::new(board_state), chunks[0]);
+        frame.render_widget(StatusBar::new(conn_state, server_url, last_update), chunks[1]);
+    };
+
+    // Initial draw
     let board_state = board_rx.borrow().clone();
+    let conn_state = conn_rx.borrow().clone();
     terminal.draw(|frame| {
-        frame.render_widget(BoardWidget::new(&board_state), frame.area());
+        draw(frame, &board_state, &conn_state, server_url, last_update);
     })?;
 
     loop {
         tokio::select! {
             result = board_rx.changed() => {
                 if result.is_err() {
-                    break; // Sender dropped
+                    break;
                 }
+                last_update = Some(Instant::now());
                 let board_state = board_rx.borrow().clone();
+                let conn_state = conn_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    frame.render_widget(BoardWidget::new(&board_state), frame.area());
+                    draw(frame, &board_state, &conn_state, server_url, last_update);
                 })?;
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {
-                if event::poll(std::time::Duration::from_millis(0))? {
+            _ = conn_rx.changed() => {
+                let board_state = board_rx.borrow().clone();
+                let conn_state = conn_rx.borrow().clone();
+                terminal.draw(|frame| {
+                    draw(frame, &board_state, &conn_state, server_url, last_update);
+                })?;
+            }
+            _ = tokio::time::sleep(tick_duration) => {
+                let board_state = board_rx.borrow().clone();
+                let conn_state = conn_rx.borrow().clone();
+                terminal.draw(|frame| {
+                    draw(frame, &board_state, &conn_state, server_url, last_update);
+                })?;
+
+                if event::poll(Duration::from_millis(0))? {
                     match event::read()? {
                         Event::Key(key) if key.kind == KeyEventKind::Press => {
                             match key.code {
                                 KeyCode::Char('q') | KeyCode::Esc => break,
+                                KeyCode::Char('c')
+                                    if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                                {
+                                    break
+                                }
                                 _ => {}
                             }
-                        }
-                        Event::Resize(_, _) => {
-                            let board_state = board_rx.borrow().clone();
-                            terminal.draw(|frame| {
-                                frame.render_widget(BoardWidget::new(&board_state), frame.area());
-                            })?;
                         }
                         _ => {}
                     }

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -21,6 +21,9 @@ enum Command {
         /// WebSocket server URL
         #[arg(long, default_value = "ws://localhost:3000/ws")]
         server: String,
+        /// Target frames per second for the UI refresh rate
+        #[arg(long, default_value_t = 30)]
+        fps: u16,
     },
     /// Push a message to the board
     Push,
@@ -37,7 +40,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Watch { server } => commands::watch::run(server).await,
+        Command::Watch { server, fps } => commands::watch::run(server, fps).await,
         Command::Serve => {
             eprintln!("serve is not yet implemented");
             Ok(())

--- a/crates/herald-cli/src/ui/mod.rs
+++ b/crates/herald-cli/src/ui/mod.rs
@@ -1,3 +1,5 @@
 mod board_widget;
+mod status_bar;
 
 pub use board_widget::BoardWidget;
+pub use status_bar::StatusBar;

--- a/crates/herald-cli/src/ui/status_bar.rs
+++ b/crates/herald-cli/src/ui/status_bar.rs
@@ -1,0 +1,143 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::widgets::Widget;
+
+use crate::ws_client::ConnectionState;
+
+pub struct StatusBar<'a> {
+    connection_state: &'a ConnectionState,
+    server_url: &'a str,
+    last_update: Option<std::time::Instant>,
+}
+
+impl<'a> StatusBar<'a> {
+    pub fn new(
+        connection_state: &'a ConnectionState,
+        server_url: &'a str,
+        last_update: Option<std::time::Instant>,
+    ) -> Self {
+        Self {
+            connection_state,
+            server_url,
+            last_update,
+        }
+    }
+
+    fn format_elapsed(elapsed: std::time::Duration) -> String {
+        let total_secs = elapsed.as_secs();
+        if total_secs < 60 {
+            format!("Updated {total_secs}s ago")
+        } else if total_secs < 3600 {
+            let mins = total_secs / 60;
+            let secs = total_secs % 60;
+            format!("Updated {mins}m {secs}s ago")
+        } else {
+            let hours = total_secs / 3600;
+            let mins = (total_secs % 3600) / 60;
+            format!("Updated {hours}h {mins}m ago")
+        }
+    }
+}
+
+impl Widget for StatusBar<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        let y = area.y;
+
+        // Left: connection state
+        let (state_text, state_color) = match self.connection_state {
+            ConnectionState::Connected => ("● Connected".to_string(), Color::Green),
+            ConnectionState::Connecting => ("◌ Connecting...".to_string(), Color::Yellow),
+            ConnectionState::Reconnecting {
+                attempt,
+                next_retry_secs,
+            } => (
+                format!("◌ Reconnecting (attempt {attempt}, retry in {next_retry_secs}s)..."),
+                Color::Yellow,
+            ),
+            ConnectionState::Disconnected => ("✖ Disconnected".to_string(), Color::Red),
+        };
+        let left_x = area.x.saturating_add(1);
+        buf.set_string(left_x, y, &state_text, Style::default().fg(state_color));
+
+        // Center: server URL
+        let url_len = self.server_url.len() as u16;
+        let center_x = area.x + area.width.saturating_sub(url_len) / 2;
+        buf.set_string(
+            center_x,
+            y,
+            self.server_url,
+            Style::default().fg(Color::DarkGray),
+        );
+
+        // Right: time since last update
+        let time_text = match self.last_update {
+            Some(instant) => Self::format_elapsed(instant.elapsed()),
+            None => "No updates yet".to_string(),
+        };
+        let time_len = time_text.len() as u16;
+        let right_x = area.x + area.width.saturating_sub(time_len + 1);
+        buf.set_string(right_x, y, &time_text, Style::default().fg(Color::Gray));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::{Position, Rect};
+
+    #[test]
+    fn test_connected_status() {
+        let state = ConnectionState::Connected;
+        let area = Rect::new(0, 0, 80, 1);
+        let mut buf = Buffer::empty(area);
+
+        let widget = StatusBar::new(&state, "ws://localhost:3000/ws", None);
+        widget.render(area, &mut buf);
+
+        let content: String = (0..area.width)
+            .map(|x| buf.cell(Position::new(x, 0)).unwrap().symbol().to_string())
+            .collect();
+        assert!(content.contains("● Connected"));
+
+        // Verify green color on the connection indicator cells
+        let left_x = 1; // 1 char padding
+        let cell = buf.cell(Position::new(left_x, 0)).unwrap();
+        assert_eq!(cell.fg, Color::Green);
+    }
+
+    #[test]
+    fn test_reconnecting_shows_attempt() {
+        let state = ConnectionState::Reconnecting {
+            attempt: 3,
+            next_retry_secs: 5,
+        };
+        let area = Rect::new(0, 0, 100, 1);
+        let mut buf = Buffer::empty(area);
+
+        let widget = StatusBar::new(&state, "ws://localhost:3000/ws", None);
+        widget.render(area, &mut buf);
+
+        let content: String = (0..area.width)
+            .map(|x| buf.cell(Position::new(x, 0)).unwrap().symbol().to_string())
+            .collect();
+        assert!(
+            content.contains("attempt 3"),
+            "Expected 'attempt 3' in: {content}"
+        );
+        assert!(
+            content.contains("retry in 5s"),
+            "Expected 'retry in 5s' in: {content}"
+        );
+
+        // Verify yellow color
+        let left_x = 1;
+        let cell = buf.cell(Position::new(left_x, 0)).unwrap();
+        assert_eq!(cell.fg, Color::Yellow);
+    }
+}

--- a/crates/herald-cli/src/ws_client.rs
+++ b/crates/herald-cli/src/ws_client.rs
@@ -8,21 +8,43 @@ use tokio_tungstenite::tungstenite::Message;
 const INITIAL_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 30;
 
+/// Connection state visible to the UI layer.
+#[derive(Clone, Debug)]
+pub enum ConnectionState {
+    /// Initial connection attempt in progress.
+    Connecting,
+    /// WebSocket connection is active.
+    Connected,
+    /// Connection lost, attempting to reconnect.
+    Reconnecting { attempt: u32, next_retry_secs: u64 },
+    /// Disconnected (all receivers dropped or permanently failed).
+    Disconnected,
+}
+
 pub struct WsClient {
     server_url: String,
     board_tx: watch::Sender<BoardState>,
+    conn_tx: watch::Sender<ConnectionState>,
 }
 
 impl WsClient {
-    /// Create a new WsClient and return it along with a watch::Receiver
-    /// that will be updated whenever a new BoardState arrives from the server.
-    pub fn new(server_url: String) -> (Self, watch::Receiver<BoardState>) {
+    /// Create a new WsClient and return it along with watch receivers for
+    /// board state updates and connection state changes.
+    pub fn new(
+        server_url: String,
+    ) -> (
+        Self,
+        watch::Receiver<BoardState>,
+        watch::Receiver<ConnectionState>,
+    ) {
         let (board_tx, board_rx) = watch::channel(BoardState::default());
+        let (conn_tx, conn_rx) = watch::channel(ConnectionState::Connecting);
         let client = Self {
             server_url,
             board_tx,
+            conn_tx,
         };
-        (client, board_rx)
+        (client, board_rx, conn_rx)
     }
 
     /// Run the connection loop. Connects to the server, receives messages,
@@ -31,17 +53,30 @@ impl WsClient {
     /// Should be spawned as a tokio task.
     pub async fn run(&self) {
         let mut backoff_secs = INITIAL_BACKOFF_SECS;
+        let mut attempt: u32 = 0;
 
         loop {
             if self.board_tx.is_closed() {
+                let _ = self.conn_tx.send(ConnectionState::Disconnected);
                 tracing::info!("All receivers dropped, stopping WS client");
                 return;
+            }
+
+            if attempt == 0 {
+                let _ = self.conn_tx.send(ConnectionState::Connecting);
+            } else {
+                let _ = self.conn_tx.send(ConnectionState::Reconnecting {
+                    attempt,
+                    next_retry_secs: backoff_secs,
+                });
             }
 
             match tokio_tungstenite::connect_async(&self.server_url).await {
                 Ok((ws_stream, _)) => {
                     tracing::info!("Connected to {}", self.server_url);
+                    let _ = self.conn_tx.send(ConnectionState::Connected);
                     backoff_secs = INITIAL_BACKOFF_SECS;
+                    attempt = 0;
 
                     let (mut sink, mut stream) = ws_stream.split();
 
@@ -92,19 +127,27 @@ impl WsClient {
                     }
                 }
                 Err(err) => {
+                    attempt += 1;
                     tracing::warn!(
                         "Connection to {} failed: {err}. Retrying in {backoff_secs}s...",
                         self.server_url
                     );
+                    let _ = self.conn_tx.send(ConnectionState::Reconnecting {
+                        attempt,
+                        next_retry_secs: backoff_secs,
+                    });
                     tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                     backoff_secs = (backoff_secs * 2).min(MAX_BACKOFF_SECS);
                     continue;
                 }
             }
 
-            // Brief pause before reconnecting after a clean disconnect.
-            // Only reached after a successful connection that later disconnected.
-            // The `continue` in the Err branch skips this to avoid double-sleeping.
+            // After a successful connection ends, signal reconnecting before the pause.
+            attempt += 1;
+            let _ = self.conn_tx.send(ConnectionState::Reconnecting {
+                attempt,
+                next_retry_secs: INITIAL_BACKOFF_SECS,
+            });
             tokio::time::sleep(Duration::from_secs(INITIAL_BACKOFF_SECS)).await;
         }
     }


### PR DESCRIPTION
## Description

Add a full terminal UI for the herald watch command with a live-updating board grid, connection status bar, and keyboard controls.

### What's included

- **Board grid widget**: Renders the 6×22 board using Unicode box-drawing characters. Each cell is a 3-character tile displaying characters centered, color blocks via terminal background colors, or blanks. The grid is centered in the terminal viewport, with a minimum-size warning when the terminal is too small (89×13 required).
- **Status bar**: A single-row bar at the bottom displays:
  - Connection state with color coding: green (Connected), yellow (Connecting/Reconnecting), red (Disconnected)
  - Reconnection details: attempt count and next retry delay
  - Server URL (centered)
  - Time since last board update (right-aligned, live-updating)
- **Connection state tracking**: The WebSocket client now exposes a ConnectionState enum via a watch channel, tracking lifecycle transitions (Connecting → Connected → Reconnecting → Disconnected) with attempt counts.
- **Full-screen TUI event loop**: Alternate screen with hidden cursor, layout split (board + status bar), three-branch 	okio::select! for board updates, connection state changes, and tick-based redraws.
- **Keyboard controls**: q/Esc/Ctrl+C to quit, with guaranteed terminal restoration on exit.
- **--fps flag**: Controls the UI refresh rate (default 30), used for tick-based status bar updates.
- **Unit tests**: 6 widget tests covering grid corners, character cells, color backgrounds, minimum-size warning, connected status display, and reconnecting status display.

## Related Issues

Closes #18 
Closes #19 


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [ ] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)