### PR TITLE
feat: add queue rotation, countdown rendering, and expired message cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connection status bar showing state (Connected/Connecting/Reconnecting/Disconnected), server URL, and time since last update
 - `--fps` option on `herald watch` to control UI refresh rate (default 30)
 - Server-side WebSocket ping/pong heartbeat (30s interval, 10s timeout) to detect and close stale connections
+- Background queue rotation task with configurable interval (`rotation_interval_secs` in config)
+- Automatic expired message cleanup during rotation (per spec §5.7)
+- Countdown timer rendering on the board grid with label, formatted time remaining, and template placeholders

--- a/crates/herald-common/src/countdown.rs
+++ b/crates/herald-common/src/countdown.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-use crate::{CellContent, Countdown, Grid, BOARD_COLS, BOARD_ROWS};
+use crate::{BOARD_COLS, BOARD_ROWS, CellContent, Countdown, Grid};
 
 /// Render a countdown onto the 6×22 board grid.
 ///
@@ -188,8 +188,16 @@ mod tests {
         let grid = render_countdown_grid(&cd, now);
 
         for col in 0..BOARD_COLS {
-            assert_eq!(grid.0[2][col], CellContent::Blank, "row 2, col {col} not blank");
-            assert_eq!(grid.0[5][col], CellContent::Blank, "row 5, col {col} not blank");
+            assert_eq!(
+                grid.0[2][col],
+                CellContent::Blank,
+                "row 2, col {col} not blank"
+            );
+            assert_eq!(
+                grid.0[5][col],
+                CellContent::Blank,
+                "row 5, col {col} not blank"
+            );
         }
     }
 

--- a/crates/herald-common/src/countdown.rs
+++ b/crates/herald-common/src/countdown.rs
@@ -1,0 +1,222 @@
+use chrono::{DateTime, Utc};
+
+use crate::{CellContent, Countdown, Grid, BOARD_COLS, BOARD_ROWS};
+
+/// Render a countdown onto the 6×22 board grid.
+///
+/// Layout:
+/// - Rows 0-1: countdown label (centered, split at 22 chars)
+/// - Row 2: blank
+/// - Rows 3-4: formatted time remaining (centered, split on "/")
+/// - Row 5: blank
+pub fn render_countdown_grid(countdown: &Countdown, now: DateTime<Utc>) -> Grid {
+    let mut grid = Grid::blank();
+
+    // ── Label on rows 0–1 ────────────────────────────────
+    let label_chars: Vec<char> = countdown.label.chars().collect();
+    let row0: Vec<char> = label_chars.iter().take(BOARD_COLS).copied().collect();
+    place_text_centered(&mut grid, 0, &row0);
+
+    if label_chars.len() > BOARD_COLS {
+        let row1: Vec<char> = label_chars[BOARD_COLS..]
+            .iter()
+            .take(BOARD_COLS)
+            .copied()
+            .collect();
+        place_text_centered(&mut grid, 1, &row1);
+    }
+
+    // ── Time remaining on rows 3–4 ──────────────────────
+    let remaining = if countdown.target > now {
+        countdown.target - now
+    } else {
+        chrono::Duration::zero()
+    };
+
+    let formatted = format_template(&countdown.format_template, remaining);
+
+    // Split on "/" for multi-row time display
+    let parts: Vec<&str> = formatted.splitn(2, '/').collect();
+    let time_row0: Vec<char> = parts[0].trim().chars().take(BOARD_COLS).collect();
+    place_text_centered(&mut grid, 3, &time_row0);
+
+    if parts.len() > 1 {
+        let time_row1: Vec<char> = parts[1].trim().chars().take(BOARD_COLS).collect();
+        place_text_centered(&mut grid, 4, &time_row1);
+    }
+
+    grid
+}
+
+/// Replace format template placeholders with computed time values.
+fn format_template(template: &str, duration: chrono::Duration) -> String {
+    let total_secs = duration.num_seconds().max(0);
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
+    let mins = (total_secs % 3600) / 60;
+    let secs = total_secs % 60;
+
+    // Replace longest tokens first to avoid partial matches
+    template
+        .replace("{DDD}", &format!("{days:03}"))
+        .replace("{DD}", &format!("{days:02}"))
+        .replace("{D}", &days.to_string())
+        .replace("{HH}", &format!("{hours:02}"))
+        .replace("{H}", &hours.to_string())
+        .replace("{MM}", &format!("{mins:02}"))
+        .replace("{M}", &mins.to_string())
+        .replace("{SS}", &format!("{secs:02}"))
+        .replace("{S}", &secs.to_string())
+}
+
+/// Place characters centered on a grid row.
+fn place_text_centered(grid: &mut Grid, row: usize, chars: &[char]) {
+    if row >= BOARD_ROWS || chars.is_empty() {
+        return;
+    }
+    let len = chars.len().min(BOARD_COLS);
+    let start = (BOARD_COLS - len) / 2;
+    for (i, &ch) in chars[..len].iter().enumerate() {
+        grid.0[row][start + i] = CellContent::Char(ch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ZeroBehavior;
+    use uuid::Uuid;
+
+    fn make_countdown(label: &str, target: DateTime<Utc>, template: &str) -> Countdown {
+        Countdown {
+            id: Uuid::new_v4(),
+            label: label.to_string(),
+            target,
+            format_template: template.to_string(),
+            zero_behavior: ZeroBehavior::ShowZero,
+            queue_position: 0,
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_format_template_basic() {
+        let dur = chrono::Duration::seconds(42 * 86400 + 7 * 3600 + 31 * 60 + 15);
+        let result = format_template("{DDD} DAYS  {HH}:{MM}:{SS}", dur);
+        assert_eq!(result, "042 DAYS  07:31:15");
+    }
+
+    #[test]
+    fn test_format_template_no_leading_zeros() {
+        let dur = chrono::Duration::seconds(5 * 86400 + 3 * 3600 + 9 * 60 + 2);
+        let result = format_template("{D} DAYS  {H}:{M}:{S}", dur);
+        assert_eq!(result, "5 DAYS  3:9:2");
+    }
+
+    #[test]
+    fn test_format_template_zero_duration() {
+        let dur = chrono::Duration::zero();
+        let result = format_template("{DDD} DAYS  {HH}:{MM}:{SS}", dur);
+        assert_eq!(result, "000 DAYS  00:00:00");
+    }
+
+    #[test]
+    fn test_format_template_over_99_days() {
+        let dur = chrono::Duration::seconds(365 * 86400 + 12 * 3600);
+        let result = format_template("{D} DAYS  {HH}:{MM}:{SS}", dur);
+        assert_eq!(result, "365 DAYS  12:00:00");
+    }
+
+    #[test]
+    fn test_format_template_ddd_over_999() {
+        let dur = chrono::Duration::seconds(1234 * 86400);
+        let result = format_template("{DDD} DAYS", dur);
+        assert_eq!(result, "1234 DAYS");
+    }
+
+    #[test]
+    fn test_render_countdown_label_placed_on_row_0() {
+        let now = Utc::now();
+        let target = now + chrono::Duration::hours(1);
+        let cd = make_countdown("LAUNCH", target, "{HH}:{MM}:{SS}");
+        let grid = render_countdown_grid(&cd, now);
+
+        let start = (BOARD_COLS - 6) / 2; // 8
+        assert_eq!(grid.0[0][start], CellContent::Char('L'));
+        assert_eq!(grid.0[0][start + 1], CellContent::Char('A'));
+        assert_eq!(grid.0[0][start + 5], CellContent::Char('H'));
+    }
+
+    #[test]
+    fn test_render_countdown_time_on_row_3() {
+        let now = Utc::now();
+        let target = now + chrono::Duration::seconds(3661); // 1h 1m 1s
+        let cd = make_countdown("TEST", target, "{HH}:{MM}:{SS}");
+        let grid = render_countdown_grid(&cd, now);
+
+        let time_str = "01:01:01";
+        let start = (BOARD_COLS - time_str.len()) / 2; // 7
+        for (i, ch) in time_str.chars().enumerate() {
+            assert_eq!(
+                grid.0[3][start + i],
+                CellContent::Char(ch),
+                "mismatch at row 3, col {}",
+                start + i
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_countdown_past_target_shows_zero() {
+        let now = Utc::now();
+        let target = now - chrono::Duration::hours(1);
+        let cd = make_countdown("DONE", target, "{HH}:{MM}:{SS}");
+        let grid = render_countdown_grid(&cd, now);
+
+        let time_str = "00:00:00";
+        let start = (BOARD_COLS - time_str.len()) / 2;
+        for (i, ch) in time_str.chars().enumerate() {
+            assert_eq!(grid.0[3][start + i], CellContent::Char(ch));
+        }
+    }
+
+    #[test]
+    fn test_render_countdown_row_2_and_5_blank() {
+        let now = Utc::now();
+        let target = now + chrono::Duration::hours(1);
+        let cd = make_countdown("TEST", target, "{HH}:{MM}:{SS}");
+        let grid = render_countdown_grid(&cd, now);
+
+        for col in 0..BOARD_COLS {
+            assert_eq!(grid.0[2][col], CellContent::Blank, "row 2, col {col} not blank");
+            assert_eq!(grid.0[5][col], CellContent::Blank, "row 5, col {col} not blank");
+        }
+    }
+
+    #[test]
+    fn test_render_countdown_multirow_time() {
+        let now = Utc::now();
+        let target = now + chrono::Duration::seconds(42 * 86400 + 7 * 3600 + 31 * 60 + 15);
+        let cd = make_countdown("EVENT", target, "{D} DAYS  {H} HRS/{M} MIN   {S} SEC");
+        let grid = render_countdown_grid(&cd, now);
+
+        let row3_has_content = grid.0[3].iter().any(|c| *c != CellContent::Blank);
+        let row4_has_content = grid.0[4].iter().any(|c| *c != CellContent::Blank);
+        assert!(row3_has_content, "row 3 should have time content");
+        assert!(row4_has_content, "row 4 should have time content");
+    }
+
+    #[test]
+    fn test_render_countdown_long_label_wraps_to_row_1() {
+        let now = Utc::now();
+        let target = now + chrono::Duration::hours(1);
+        let cd = make_countdown("ABCDEFGHIJKLMNOPQRSTUV12345678", target, "{HH}:{MM}:{SS}");
+        let grid = render_countdown_grid(&cd, now);
+
+        let row0_has_content = grid.0[0].iter().any(|c| *c != CellContent::Blank);
+        assert!(row0_has_content, "row 0 should have label content");
+
+        let row1_has_content = grid.0[1].iter().any(|c| *c != CellContent::Blank);
+        assert!(row1_has_content, "row 1 should have label overflow");
+    }
+}

--- a/crates/herald-common/src/lib.rs
+++ b/crates/herald-common/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod countdown;
 pub mod types;
 
+pub use countdown::render_countdown_grid;
 pub use types::*;
 
 /// Board dimensions: 6 rows × 22 columns.

--- a/crates/herald-server/src/api/config.rs
+++ b/crates/herald-server/src/api/config.rs
@@ -24,6 +24,7 @@ pub async fn update(
     }
 
     db::set_config(state.pool(), &req.values).await?;
+    state.reset_rotation_timer();
     let config = db::get_config(state.pool()).await?;
     Ok(Json(config))
 }

--- a/crates/herald-server/src/api/countdowns.rs
+++ b/crates/herald-server/src/api/countdowns.rs
@@ -41,6 +41,7 @@ pub async fn create(
 
     db::create_countdown(state.pool(), &cd).await?;
     state.notify_board_update().await;
+    state.reset_rotation_timer();
 
     Ok((StatusCode::CREATED, Json(cd)))
 }
@@ -96,5 +97,6 @@ pub async fn delete(
         return Err(ApiError::NotFound(format!("countdown {id} not found")));
     }
     state.notify_board_update().await;
+    state.reset_rotation_timer();
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -34,6 +34,7 @@ pub async fn create(
 
     db::create_message(state.pool(), &msg).await?;
     state.notify_board_update().await;
+    state.reset_rotation_timer();
 
     Ok((StatusCode::CREATED, Json(msg)))
 }
@@ -90,5 +91,6 @@ pub async fn delete(
         return Err(ApiError::NotFound(format!("message {id} not found")));
     }
     state.notify_board_update().await;
+    state.reset_rotation_timer();
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -494,9 +494,10 @@ pub async fn build_board_state(pool: &SqlitePool) -> Result<BoardState, sqlx::Er
             None => Grid::blank(),
         },
         QueueItemKind::Countdown => {
-            // Countdown grid rendering is not yet implemented;
-            // broadcast a blank grid so viewers still get the metadata.
-            Grid::blank()
+            match get_countdown(pool, &current_item.id.to_string()).await? {
+                Some(cd) => herald_common::render_countdown_grid(&cd, chrono::Utc::now()),
+                None => Grid::blank(),
+            }
         }
     };
 
@@ -512,4 +513,63 @@ pub async fn build_board_state(pool: &SqlitePool) -> Result<BoardState, sqlx::Er
         current_item: Some(item_info),
         timestamp: chrono::Utc::now(),
     })
+}
+
+/// Advance the rotation index to the next queue item and return the new index.
+pub async fn advance_current_index(pool: &SqlitePool) -> Result<i64, sqlx::Error> {
+    sqlx::query("UPDATE rotation_state SET current_index = current_index + 1 WHERE id = 1")
+        .execute(pool)
+        .await?;
+    get_current_index(pool).await
+}
+
+/// Read the rotation interval from the config table. Defaults to 10 seconds.
+pub async fn get_rotation_interval(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let row = sqlx::query("SELECT value FROM configuration WHERE key = 'rotation_interval_secs'")
+        .fetch_optional(pool)
+        .await?;
+
+    match row {
+        Some(row) => {
+            let value: String = row.get("value");
+            Ok(value.parse::<u64>().unwrap_or(10))
+        }
+        None => Ok(10),
+    }
+}
+
+// ── Expiry-aware rotation ───────────────────────────────────────────
+
+/// Delete all messages whose expiry time has passed. Returns the number of deleted messages.
+pub async fn delete_expired_messages(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let result =
+        sqlx::query("DELETE FROM messages WHERE expires_at IS NOT NULL AND expires_at <= ?")
+            .bind(&now)
+            .execute(pool)
+            .await?;
+    Ok(result.rows_affected())
+}
+
+/// Update the last_rotation timestamp to now.
+pub async fn update_last_rotation(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query("UPDATE rotation_state SET last_rotation = ? WHERE id = 1")
+        .bind(&now)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Advance the rotation to the next valid (non-expired) queue item.
+///
+/// Returns the number of expired messages that were deleted.
+///
+/// After this call, `build_board_state` will return the next valid item
+/// (or a default empty state if the queue is now empty).
+pub async fn advance_to_next_valid_item(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let deleted = delete_expired_messages(pool).await?;
+    advance_current_index(pool).await?;
+    update_last_rotation(pool).await?;
+    Ok(deleted)
 }

--- a/crates/herald-server/src/lib.rs
+++ b/crates/herald-server/src/lib.rs
@@ -9,6 +9,80 @@ use axum::routing::{delete, get, post, put};
 
 use state::AppState;
 
+/// Spawn the background rotation task that advances the queue on a timer.
+/// Returns the JoinHandle for the spawned task.
+pub fn start_rotation_task(state: AppState) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!("Rotation task started");
+
+        loop {
+            let interval_secs = match db::get_rotation_interval(state.pool()).await {
+                Ok(secs) => secs,
+                Err(e) => {
+                    tracing::error!("Failed to read rotation interval: {e}");
+                    10 // fallback default
+                }
+            };
+
+            if interval_secs == 0 {
+                tracing::debug!("Rotation disabled (interval = 0), waiting for config change");
+                state.rotation_notified().await;
+                continue;
+            }
+
+            tracing::debug!("Next rotation tick in {interval_secs}s");
+
+            tokio::select! {
+                _ = tokio::time::sleep(std::time::Duration::from_secs(interval_secs)) => {
+                    match db::get_queue(state.pool()).await {
+                        Ok(queue) if queue.is_empty() => {
+                            tracing::trace!("Rotation tick: queue is empty, nothing to rotate");
+                        }
+                        Ok(queue) if queue.len() == 1 => {
+                            // Single item — don't advance, but do clean up expired items
+                            // (if the single item is expired, this will remove it)
+                            match db::delete_expired_messages(state.pool()).await {
+                                Ok(0) => {
+                                    tracing::trace!("Rotation tick: single item in queue, skipping rotation");
+                                }
+                                Ok(deleted) => {
+                                    tracing::info!("Rotation: removed {deleted} expired message(s), queue may now be empty");
+                                    state.notify_board_update().await;
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to clean expired messages: {e}");
+                                }
+                            }
+                        }
+                        Ok(_) => {
+                            // Multiple items — advance with expiry handling
+                            match db::advance_to_next_valid_item(state.pool()).await {
+                                Ok(deleted) => {
+                                    if deleted > 0 {
+                                        tracing::info!("Rotation: removed {deleted} expired message(s)");
+                                    }
+                                    tracing::debug!("Rotation tick: advanced to next item");
+                                    state.notify_board_update().await;
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to advance rotation: {e}");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to read queue for rotation: {e}");
+                        }
+                    }
+                }
+                _ = state.rotation_notified() => {
+                    tracing::debug!("Rotation timer reset");
+                    continue;
+                }
+            }
+        }
+    })
+}
+
 /// Build the full Axum router with all routes.
 pub fn build_router(state: AppState) -> Router {
     // Admin routes — protected by bearer token auth

--- a/crates/herald-server/src/main.rs
+++ b/crates/herald-server/src/main.rs
@@ -36,6 +36,7 @@ async fn main() {
 
     // Build app
     let state = AppState::new(pool, admin_token);
+    herald_server::start_rotation_task(state.clone());
     let app = build_router(state);
 
     // Start server

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use herald_common::{Grid, ServerMessage};
 use sqlx::SqlitePool;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, Notify, broadcast};
 
 const BROADCAST_CAPACITY: usize = 16;
 
@@ -24,6 +24,8 @@ struct InnerState {
     /// Guards the build-board-state → broadcast path so concurrent mutations
     /// cannot interleave and produce out-of-order previous_grid values.
     pub notify_lock: Mutex<Grid>,
+    /// Signals the rotation task to restart its timer (e.g., after config change or queue mutation).
+    pub rotation_notify: Notify,
 }
 
 impl AppState {
@@ -38,6 +40,7 @@ impl AppState {
                 viewer_count: AtomicUsize::new(0),
                 next_client_id: AtomicU64::new(1),
                 notify_lock: Mutex::new(Grid::blank()),
+                rotation_notify: Notify::new(),
             }),
         }
     }
@@ -106,5 +109,17 @@ impl AppState {
                 tracing::error!("Failed to build board state for broadcast: {e}");
             }
         }
+    }
+
+    /// Signal the rotation task to reset its timer and re-read the interval.
+    /// Call this after config changes or queue mutations.
+    pub fn reset_rotation_timer(&self) {
+        self.inner.rotation_notify.notify_one();
+    }
+
+    /// Wait for a rotation timer reset signal.
+    /// Used by the rotation task in its select loop.
+    pub async fn rotation_notified(&self) {
+        self.inner.rotation_notify.notified().await;
     }
 }

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -1073,3 +1073,317 @@ async fn ws_initial_state_with_existing_message() {
     drop(ws_stream);
     cleanup(&db_path);
 }
+
+// ── Rotation & expiry tests ─────────────────────────────────────
+
+#[tokio::test]
+async fn rotation_advance_cycles_through_queue() {
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Create 3 messages (A, B, C) via HTTP
+    let client = reqwest::Client::new();
+    let mut message_ids = Vec::new();
+    for label in &["AAA", "BBB", "CCC"] {
+        let resp = client
+            .post(format!("http://{addr}/api/messages"))
+            .header("authorization", format!("Bearer {TEST_TOKEN}"))
+            .json(&serde_json::json!({
+                "grid": text_grid(label),
+                "h_align": "center",
+                "v_align": "middle"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        message_ids.push(body["id"].as_str().unwrap().to_string());
+    }
+
+    let pool = state.pool();
+
+    // Initial board state should show the first message (index 0)
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    let item = board
+        .current_item
+        .as_ref()
+        .expect("should have a current item");
+    assert_eq!(item.id.to_string(), message_ids[0]);
+
+    // Advance → should show message B
+    herald_server::db::advance_to_next_valid_item(pool)
+        .await
+        .unwrap();
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    let item = board
+        .current_item
+        .as_ref()
+        .expect("should have a current item");
+    assert_eq!(item.id.to_string(), message_ids[1]);
+
+    // Advance → should show message C
+    herald_server::db::advance_to_next_valid_item(pool)
+        .await
+        .unwrap();
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    let item = board
+        .current_item
+        .as_ref()
+        .expect("should have a current item");
+    assert_eq!(item.id.to_string(), message_ids[2]);
+
+    // Advance again → should wrap back to message A
+    herald_server::db::advance_to_next_valid_item(pool)
+        .await
+        .unwrap();
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    let item = board
+        .current_item
+        .as_ref()
+        .expect("should have a current item");
+    assert_eq!(item.id.to_string(), message_ids[0]);
+
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn rotation_skips_and_deletes_expired_messages() {
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+
+    // Create a normal (non-expiring) message
+    let resp = client
+        .post(format!("http://{addr}/api/messages"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "grid": text_grid("KEEP"),
+            "h_align": "center",
+            "v_align": "middle"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    let keep_id = resp.json::<serde_json::Value>().await.unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create an already-expired message
+    let resp = client
+        .post(format!("http://{addr}/api/messages"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "grid": text_grid("EXPIRED"),
+            "h_align": "center",
+            "v_align": "middle",
+            "expires_at": "2020-01-01T00:00:00Z"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    let pool = state.pool();
+
+    // Before cleanup, queue should have 2 items
+    let queue = herald_server::db::get_queue(pool).await.unwrap();
+    assert_eq!(queue.len(), 2);
+
+    // advance_to_next_valid_item deletes expired messages
+    let deleted = herald_server::db::advance_to_next_valid_item(pool)
+        .await
+        .unwrap();
+    assert!(
+        deleted >= 1,
+        "should have deleted at least 1 expired message"
+    );
+
+    // Queue should now have only the non-expired message
+    let queue = herald_server::db::get_queue(pool).await.unwrap();
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].id.to_string(), keep_id);
+
+    // Board state should show the kept message
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    let item = board
+        .current_item
+        .as_ref()
+        .expect("should have a current item");
+    assert_eq!(item.id.to_string(), keep_id);
+
+    cleanup(&db_path);
+}
+
+#[tokio::test]
+async fn rotation_all_expired_results_in_empty_board() {
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = reqwest::Client::new();
+
+    // Create 2 already-expired messages
+    for label in &["GONE1", "GONE2"] {
+        let resp = client
+            .post(format!("http://{addr}/api/messages"))
+            .header("authorization", format!("Bearer {TEST_TOKEN}"))
+            .json(&serde_json::json!({
+                "grid": text_grid(label),
+                "h_align": "center",
+                "v_align": "middle",
+                "expires_at": "2020-01-01T00:00:00Z"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    }
+
+    let pool = state.pool();
+
+    // Before cleanup, queue should have 2 items
+    let queue = herald_server::db::get_queue(pool).await.unwrap();
+    assert_eq!(queue.len(), 2);
+
+    // advance_to_next_valid_item should delete both expired messages
+    let deleted = herald_server::db::advance_to_next_valid_item(pool)
+        .await
+        .unwrap();
+    assert_eq!(deleted, 2, "should have deleted 2 expired messages");
+
+    // Queue should be empty
+    let queue = herald_server::db::get_queue(pool).await.unwrap();
+    assert!(
+        queue.is_empty(),
+        "queue should be empty after all messages expired"
+    );
+
+    // Board state should be default (no current_item)
+    let board = herald_server::db::build_board_state(pool).await.unwrap();
+    assert!(
+        board.current_item.is_none(),
+        "current_item should be None when all messages are expired"
+    );
+
+    cleanup(&db_path);
+}
+
+// ── Countdown rendering tests ───────────────────────────────────
+
+#[tokio::test]
+async fn countdown_renders_on_board_state() {
+    let db_path = format!(
+        "herald_test_{}.db",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+    let database_url = format!("sqlite:{db_path}");
+    let pool = herald_server::db::init_pool(&database_url).await.unwrap();
+    let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
+    let app = herald_server::build_router(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Create a countdown 1 hour in the future
+    let client = reqwest::Client::new();
+    let future_time = chrono::Utc::now() + chrono::Duration::hours(1);
+    let resp = client
+        .post(format!("http://{addr}/api/countdowns"))
+        .header("authorization", format!("Bearer {TEST_TOKEN}"))
+        .json(&serde_json::json!({
+            "label": "LAUNCH",
+            "target": future_time.to_rfc3339()
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // Build the board state — should have the countdown rendered (not blank)
+    let board_state = herald_server::db::build_board_state(state.pool()).await.unwrap();
+
+    // current_item should be the countdown
+    let item = board_state.current_item.unwrap();
+    assert_eq!(item.kind, herald_common::QueueItemKind::Countdown);
+    assert_eq!(item.label, "LAUNCH");
+
+    // Grid should NOT be entirely blank (countdown renders label + time)
+    let has_content = board_state.grid.0.iter().any(|row| {
+        row.iter().any(|cell| *cell != herald_common::CellContent::Blank)
+    });
+    assert!(has_content, "countdown grid should have rendered content, not be blank");
+
+    // Row 0 should contain the label "LAUNCH"
+    let row0_chars: String = board_state.grid.0[0]
+        .iter()
+        .filter_map(|c| match c {
+            herald_common::CellContent::Char(ch) => Some(*ch),
+            _ => None,
+        })
+        .collect();
+    assert!(row0_chars.contains("LAUNCH"), "row 0 should contain the label LAUNCH, got: {row0_chars}");
+
+    // Row 3 should contain time digits (at least "00" from hours/minutes/seconds)
+    let row3_chars: String = board_state.grid.0[3]
+        .iter()
+        .filter_map(|c| match c {
+            herald_common::CellContent::Char(ch) => Some(*ch),
+            _ => None,
+        })
+        .collect();
+    assert!(!row3_chars.is_empty(), "row 3 should contain formatted time");
+
+    // Rows 2 and 5 should be blank (separator rows)
+    for col in 0..herald_common::BOARD_COLS {
+        assert_eq!(board_state.grid.0[2][col], herald_common::CellContent::Blank);
+        assert_eq!(board_state.grid.0[5][col], herald_common::CellContent::Blank);
+    }
+
+    cleanup(&db_path);
+}

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -1346,7 +1346,9 @@ async fn countdown_renders_on_board_state() {
     assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
 
     // Build the board state — should have the countdown rendered (not blank)
-    let board_state = herald_server::db::build_board_state(state.pool()).await.unwrap();
+    let board_state = herald_server::db::build_board_state(state.pool())
+        .await
+        .unwrap();
 
     // current_item should be the countdown
     let item = board_state.current_item.unwrap();
@@ -1355,9 +1357,13 @@ async fn countdown_renders_on_board_state() {
 
     // Grid should NOT be entirely blank (countdown renders label + time)
     let has_content = board_state.grid.0.iter().any(|row| {
-        row.iter().any(|cell| *cell != herald_common::CellContent::Blank)
+        row.iter()
+            .any(|cell| *cell != herald_common::CellContent::Blank)
     });
-    assert!(has_content, "countdown grid should have rendered content, not be blank");
+    assert!(
+        has_content,
+        "countdown grid should have rendered content, not be blank"
+    );
 
     // Row 0 should contain the label "LAUNCH"
     let row0_chars: String = board_state.grid.0[0]
@@ -1367,7 +1373,10 @@ async fn countdown_renders_on_board_state() {
             _ => None,
         })
         .collect();
-    assert!(row0_chars.contains("LAUNCH"), "row 0 should contain the label LAUNCH, got: {row0_chars}");
+    assert!(
+        row0_chars.contains("LAUNCH"),
+        "row 0 should contain the label LAUNCH, got: {row0_chars}"
+    );
 
     // Row 3 should contain time digits (at least "00" from hours/minutes/seconds)
     let row3_chars: String = board_state.grid.0[3]
@@ -1377,12 +1386,21 @@ async fn countdown_renders_on_board_state() {
             _ => None,
         })
         .collect();
-    assert!(!row3_chars.is_empty(), "row 3 should contain formatted time");
+    assert!(
+        !row3_chars.is_empty(),
+        "row 3 should contain formatted time"
+    );
 
     // Rows 2 and 5 should be blank (separator rows)
     for col in 0..herald_common::BOARD_COLS {
-        assert_eq!(board_state.grid.0[2][col], herald_common::CellContent::Blank);
-        assert_eq!(board_state.grid.0[5][col], herald_common::CellContent::Blank);
+        assert_eq!(
+            board_state.grid.0[2][col],
+            herald_common::CellContent::Blank
+        );
+        assert_eq!(
+            board_state.grid.0[5][col],
+            herald_common::CellContent::Blank
+        );
     }
 
     cleanup(&db_path);


### PR DESCRIPTION
## Description

Implement server-side queue rotation with countdown rendering, expired message handling, and runtime-configurable rotation interval.

### What's included

- **Rotation background task**: A `tokio::spawn` task reads `rotation_interval_secs` from the config table on each iteration, advances the queue, and broadcasts the new board state. Supports `interval = 0` to disable rotation. The timer is resettable — queue mutations and config changes trigger an immediate restart.
- **Expiry-aware rotation**: On each tick, expired messages (`expires_at` in the past) are deleted before advancing. If all items expire, the queue empties and the splash screen is displayed. Single-item queues skip rotation but still clean up expired items.
- **Countdown grid rendering**: New `render_countdown_grid` function in `herald-common` renders countdown timers onto the 6×22 board. Label is centered on rows 0–1, formatted time remaining on rows 3–4 (with `/` delimiter for two-row layouts). Supports format template placeholders (`{D}`, `{DD}`, `{DDD}`, `{H}`, `{HH}`, `{M}`, `{MM}`, `{S}`, `{SS}`). Handles >99 days gracefully and shows all zeros when past target.
- **Countdown wiring**: `build_board_state` now fetches the full countdown from DB and renders it instead of returning a blank grid.
- **Reset signals**: Config updates, message create/delete, and countdown create/delete all reset the rotation timer so changes take effect immediately.

## Related Issues

Closes #20 
Closes #21 
Closes #22 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [ ] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)