### PR TITLE
add countdown refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Background queue rotation task with configurable interval (`rotation_interval_secs` in config)
 - Automatic expired message cleanup during rotation (per spec §5.7)
 - Countdown timer rendering on the board grid with label, formatted time remaining, and template placeholders
+- Real-time countdown refresh (1-second broadcasts) when a countdown is the active display item
+- Per-countdown zero behavior: `ShowZero`, `Remove`, `Pause`, and `ShowMessage` when countdown reaches zero
+- Soft-delete for expired queue items (preserved in history with `deleted_at` timestamp)
+- Periodic cleanup task (60s interval) that auto-expires messages past their `expires_at` time

--- a/crates/herald-server/migrations/002_soft_delete.sql
+++ b/crates/herald-server/migrations/002_soft_delete.sql
@@ -1,0 +1,3 @@
+-- Add soft-delete support: items are marked as deleted rather than removed
+ALTER TABLE messages ADD COLUMN deleted_at TEXT;
+ALTER TABLE countdowns ADD COLUMN deleted_at TEXT;

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -53,7 +53,7 @@ pub async fn create_message(pool: &SqlitePool, msg: &Message) -> Result<(), sqlx
 }
 
 pub async fn list_messages(pool: &SqlitePool) -> Result<Vec<Message>, sqlx::Error> {
-    let rows = sqlx::query("SELECT * FROM messages ORDER BY queue_position ASC, created_at ASC")
+    let rows = sqlx::query("SELECT * FROM messages WHERE deleted_at IS NULL ORDER BY queue_position ASC, created_at ASC")
         .fetch_all(pool)
         .await?;
 
@@ -182,7 +182,7 @@ pub async fn create_countdown(pool: &SqlitePool, cd: &Countdown) -> Result<(), s
 }
 
 pub async fn list_countdowns(pool: &SqlitePool) -> Result<Vec<Countdown>, sqlx::Error> {
-    let rows = sqlx::query("SELECT * FROM countdowns ORDER BY queue_position ASC, created_at ASC")
+    let rows = sqlx::query("SELECT * FROM countdowns WHERE deleted_at IS NULL ORDER BY queue_position ASC, created_at ASC")
         .fetch_all(pool)
         .await?;
 
@@ -277,13 +277,13 @@ fn row_to_countdown(row: &sqlx::sqlite::SqliteRow) -> Countdown {
 pub async fn get_queue(pool: &SqlitePool) -> Result<Vec<QueueItem>, sqlx::Error> {
     // Messages contribute queue items
     let msg_rows = sqlx::query(
-        "SELECT id, queue_position, created_at, expires_at, grid FROM messages ORDER BY queue_position ASC, created_at ASC",
+        "SELECT id, queue_position, created_at, expires_at, grid FROM messages WHERE deleted_at IS NULL ORDER BY queue_position ASC, created_at ASC",
     )
     .fetch_all(pool)
     .await?;
 
     let cd_rows = sqlx::query(
-        "SELECT id, label, queue_position, created_at FROM countdowns ORDER BY queue_position ASC, created_at ASC",
+        "SELECT id, label, queue_position, created_at FROM countdowns WHERE deleted_at IS NULL ORDER BY queue_position ASC, created_at ASC",
     )
     .fetch_all(pool)
     .await?;
@@ -468,7 +468,7 @@ pub async fn next_queue_position(pool: &SqlitePool) -> Result<i64, sqlx::Error> 
 /// Count total queue items.
 pub async fn queue_size(pool: &SqlitePool) -> Result<usize, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT (SELECT COUNT(*) FROM messages) + (SELECT COUNT(*) FROM countdowns) as total",
+        "SELECT (SELECT COUNT(*) FROM messages WHERE deleted_at IS NULL) + (SELECT COUNT(*) FROM countdowns WHERE deleted_at IS NULL) as total",
     )
     .fetch_one(pool)
     .await?;
@@ -540,15 +540,41 @@ pub async fn get_rotation_interval(pool: &SqlitePool) -> Result<u64, sqlx::Error
 
 // ── Expiry-aware rotation ───────────────────────────────────────────
 
-/// Delete all messages whose expiry time has passed. Returns the number of deleted messages.
+/// Soft-delete all messages whose expiry time has passed. Returns the number of expired messages.
 pub async fn delete_expired_messages(pool: &SqlitePool) -> Result<u64, sqlx::Error> {
     let now = chrono::Utc::now().to_rfc3339();
+    let result = sqlx::query(
+        "UPDATE messages SET deleted_at = ? WHERE expires_at IS NOT NULL AND expires_at <= ? AND deleted_at IS NULL",
+    )
+    .bind(&now)
+    .bind(&now)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Soft-delete a specific countdown by setting deleted_at.
+pub async fn soft_delete_countdown(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+    let now = chrono::Utc::now().to_rfc3339();
     let result =
-        sqlx::query("DELETE FROM messages WHERE expires_at IS NOT NULL AND expires_at <= ?")
+        sqlx::query("UPDATE countdowns SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL")
             .bind(&now)
+            .bind(id)
             .execute(pool)
             .await?;
-    Ok(result.rows_affected())
+    Ok(result.rows_affected() > 0)
+}
+
+/// Get the current queue item based on the rotation index.
+/// Returns None if the queue is empty.
+pub async fn get_current_queue_item(pool: &SqlitePool) -> Result<Option<QueueItem>, sqlx::Error> {
+    let queue = get_queue(pool).await?;
+    if queue.is_empty() {
+        return Ok(None);
+    }
+    let current_idx = get_current_index(pool).await?;
+    let idx = (current_idx as usize) % queue.len();
+    Ok(Some(queue[idx].clone()))
 }
 
 /// Update the last_rotation timestamp to now.

--- a/crates/herald-server/src/lib.rs
+++ b/crates/herald-server/src/lib.rs
@@ -7,20 +7,27 @@ use axum::Router;
 use axum::middleware;
 use axum::routing::{delete, get, post, put};
 
+use herald_common::{QueueItemKind, ZeroBehavior};
 use state::AppState;
 
 /// Spawn the background rotation task that advances the queue on a timer.
-/// Returns the JoinHandle for the spawned task.
+///
+/// When the current queue item is a countdown, a secondary 1-second refresh
+/// interval runs in parallel with the main rotation timer so the board updates
+/// every second. When the countdown reaches zero, `ZeroBehavior` determines
+/// what happens next (show zero, remove, pause, or show a message).
 pub fn start_rotation_task(state: AppState) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tracing::info!("Rotation task started");
 
         loop {
-            let interval_secs = match db::get_rotation_interval(state.pool()).await {
+            let pool = state.pool();
+
+            let interval_secs = match db::get_rotation_interval(pool).await {
                 Ok(secs) => secs,
                 Err(e) => {
                     tracing::error!("Failed to read rotation interval: {e}");
-                    10 // fallback default
+                    10
                 }
             };
 
@@ -30,53 +37,246 @@ pub fn start_rotation_task(state: AppState) -> tokio::task::JoinHandle<()> {
                 continue;
             }
 
-            tracing::debug!("Next rotation tick in {interval_secs}s");
+            let current_item = match db::get_current_queue_item(pool).await {
+                Ok(item) => item,
+                Err(e) => {
+                    tracing::error!("Failed to read current queue item: {e}");
+                    tokio::time::sleep(std::time::Duration::from_secs(interval_secs)).await;
+                    continue;
+                }
+            };
 
-            tokio::select! {
-                _ = tokio::time::sleep(std::time::Duration::from_secs(interval_secs)) => {
-                    match db::get_queue(state.pool()).await {
-                        Ok(queue) if queue.is_empty() => {
-                            tracing::trace!("Rotation tick: queue is empty, nothing to rotate");
+            let current_item = match current_item {
+                Some(item) => item,
+                None => {
+                    tracing::trace!("Rotation tick: queue is empty, waiting");
+                    tokio::select! {
+                        _ = tokio::time::sleep(std::time::Duration::from_secs(interval_secs)) => {}
+                        _ = state.rotation_notified() => {
+                            tracing::debug!("Rotation timer reset (empty queue)");
                         }
-                        Ok(queue) if queue.len() == 1 => {
-                            // Single item — don't advance, but do clean up expired items
-                            // (if the single item is expired, this will remove it)
-                            match db::delete_expired_messages(state.pool()).await {
-                                Ok(0) => {
-                                    tracing::trace!("Rotation tick: single item in queue, skipping rotation");
-                                }
-                                Ok(deleted) => {
-                                    tracing::info!("Rotation: removed {deleted} expired message(s), queue may now be empty");
-                                    state.notify_board_update().await;
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to clean expired messages: {e}");
-                                }
+                    }
+                    continue;
+                }
+            };
+
+            match current_item.kind {
+                QueueItemKind::Countdown => {
+                    run_countdown_mode(&state, interval_secs, &current_item).await;
+                }
+                QueueItemKind::Message => {
+                    run_normal_mode(&state, interval_secs).await;
+                }
+            }
+        }
+    })
+}
+
+/// Normal rotation mode: sleep for the rotation interval, then advance.
+async fn run_normal_mode(state: &AppState, interval_secs: u64) {
+    tracing::debug!("Normal mode: next rotation tick in {interval_secs}s");
+    let pool = state.pool();
+
+    tokio::select! {
+        _ = tokio::time::sleep(std::time::Duration::from_secs(interval_secs)) => {
+            match db::get_queue(pool).await {
+                Ok(queue) if queue.is_empty() => {
+                    tracing::trace!("Rotation tick: queue is empty");
+                }
+                Ok(queue) if queue.len() == 1 => {
+                    match db::delete_expired_messages(pool).await {
+                        Ok(0) => {
+                            tracing::trace!("Rotation tick: single item, skipping");
+                        }
+                        Ok(deleted) => {
+                            tracing::info!("Rotation: removed {deleted} expired message(s)");
+                            state.notify_board_update().await;
+                        }
+                        Err(e) => tracing::error!("Failed to clean expired messages: {e}"),
+                    }
+                }
+                Ok(_) => {
+                    match db::advance_to_next_valid_item(pool).await {
+                        Ok(deleted) => {
+                            if deleted > 0 {
+                                tracing::info!("Rotation: removed {deleted} expired message(s)");
                             }
+                            tracing::debug!("Rotation tick: advanced to next item");
+                            state.notify_board_update().await;
                         }
-                        Ok(_) => {
-                            // Multiple items — advance with expiry handling
-                            match db::advance_to_next_valid_item(state.pool()).await {
-                                Ok(deleted) => {
-                                    if deleted > 0 {
-                                        tracing::info!("Rotation: removed {deleted} expired message(s)");
-                                    }
-                                    tracing::debug!("Rotation tick: advanced to next item");
-                                    state.notify_board_update().await;
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to advance rotation: {e}");
-                                }
+                        Err(e) => tracing::error!("Failed to advance rotation: {e}"),
+                    }
+                }
+                Err(e) => tracing::error!("Failed to read queue: {e}"),
+            }
+        }
+        _ = state.rotation_notified() => {
+            tracing::debug!("Rotation timer reset");
+        }
+    }
+}
+
+/// Countdown mode: a 1-second refresh interval runs in parallel with the main
+/// rotation timer. Each tick broadcasts a board update so viewers see the
+/// countdown decrement. When it reaches zero, `ZeroBehavior` takes effect.
+async fn run_countdown_mode(state: &AppState, interval_secs: u64, item: &herald_common::QueueItem) {
+    let pool = state.pool();
+    let item_id = item.id.to_string();
+
+    let countdown = match db::get_countdown(pool, &item_id).await {
+        Ok(Some(cd)) => cd,
+        Ok(None) => {
+            tracing::warn!("Countdown '{item_id}' not found, advancing");
+            db::advance_to_next_valid_item(pool).await.ok();
+            state.notify_board_update().await;
+            return;
+        }
+        Err(e) => {
+            tracing::error!("Failed to load countdown '{item_id}': {e}");
+            return;
+        }
+    };
+
+    tracing::debug!(
+        "Countdown mode: '{}' with rotation in {interval_secs}s",
+        item.label
+    );
+
+    let rotation_sleep = tokio::time::sleep(std::time::Duration::from_secs(interval_secs));
+    tokio::pin!(rotation_sleep);
+
+    let mut refresh_interval = tokio::time::interval(std::time::Duration::from_secs(1));
+    refresh_interval.tick().await; // consume the immediate first tick
+
+    let mut is_at_zero = false;
+
+    loop {
+        tokio::select! {
+            _ = &mut rotation_sleep => {
+                // Rotation timer fired — advance to next item
+                match db::get_queue(pool).await {
+                    Ok(queue) if queue.len() <= 1 => {
+                        match db::delete_expired_messages(pool).await {
+                            Ok(deleted) if deleted > 0 => {
+                                tracing::info!("Rotation: removed {deleted} expired message(s)");
                             }
+                            Err(e) => tracing::error!("Failed to clean expired messages: {e}"),
+                            _ => {}
                         }
-                        Err(e) => {
-                            tracing::error!("Failed to read queue for rotation: {e}");
+                        state.notify_board_update().await;
+                    }
+                    Ok(_) => {
+                        match db::advance_to_next_valid_item(pool).await {
+                            Ok(deleted) => {
+                                if deleted > 0 {
+                                    tracing::info!("Rotation: removed {deleted} expired message(s)");
+                                }
+                                tracing::debug!("Rotation tick: advanced past countdown");
+                                state.notify_board_update().await;
+                            }
+                            Err(e) => tracing::error!("Failed to advance rotation: {e}"),
+                        }
+                    }
+                    Err(e) => tracing::error!("Failed to read queue: {e}"),
+                }
+                break;
+            }
+            _ = refresh_interval.tick() => {
+                let now = chrono::Utc::now();
+
+                if !is_at_zero && countdown.target <= now {
+                    is_at_zero = true;
+                    match &countdown.zero_behavior {
+                        ZeroBehavior::ShowZero => {
+                            state.notify_board_update().await;
+                        }
+                        ZeroBehavior::ShowMessage { .. } => {
+                            // TODO: ShowMessage grid override is not yet wired
+                            // through build_board_state; for now, falls through
+                            // to the default zero display (same as ShowZero).
+                            state.notify_board_update().await;
+                        }
+                        ZeroBehavior::Remove => {
+                            db::soft_delete_countdown(pool, &item_id).await.ok();
+                            tracing::info!(
+                                "Countdown '{}' reached zero, removed from queue",
+                                item.label
+                            );
+                            db::advance_to_next_valid_item(pool).await.ok();
+                            state.notify_board_update().await;
+                            break;
+                        }
+                        ZeroBehavior::Pause => {
+                            tracing::info!(
+                                "Countdown '{}' reached zero, pausing rotation",
+                                item.label
+                            );
+                            state.notify_board_update().await;
+                            state.rotation_notified().await;
+                            break;
+                        }
+                    }
+                } else {
+                    state.notify_board_update().await;
+                }
+            }
+            _ = state.rotation_notified() => {
+                tracing::debug!("Rotation timer reset during countdown");
+                break;
+            }
+        }
+    }
+}
+
+/// Spawn a periodic cleanup task that soft-expires items every 60 seconds.
+/// If the currently-displayed item expires, resets the rotation timer to trigger an advance.
+pub fn start_cleanup_task(state: AppState) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!("Cleanup task started (60s interval)");
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.tick().await; // consume immediate first tick
+
+        loop {
+            interval.tick().await;
+
+            // Check which item is currently displayed BEFORE cleanup
+            let current_item_id = match db::get_current_queue_item(state.pool()).await {
+                Ok(Some(item)) => Some(item.id),
+                _ => None,
+            };
+
+            // Soft-expire all messages past their expires_at
+            match db::delete_expired_messages(state.pool()).await {
+                Ok(0) => {
+                    tracing::trace!("Cleanup: no expired items found");
+                }
+                Ok(expired) => {
+                    tracing::info!("Cleanup: soft-expired {expired} message(s)");
+
+                    // Check if the currently-displayed item was among those expired
+                    if let Some(prev_id) = current_item_id {
+                        match db::get_current_queue_item(state.pool()).await {
+                            Ok(Some(new_item)) if new_item.id != prev_id => {
+                                // Current item changed — the displayed item was expired
+                                tracing::info!(
+                                    "Cleanup: currently displayed item was expired, triggering rotation"
+                                );
+                                state.reset_rotation_timer();
+                            }
+                            Ok(None) => {
+                                // Queue is now empty
+                                tracing::info!("Cleanup: queue is now empty after expiry");
+                                state.reset_rotation_timer();
+                            }
+                            _ => {
+                                // Current item unchanged — just broadcast updated state
+                                // (queue may have shrunk but current item is still valid)
+                            }
                         }
                     }
                 }
-                _ = state.rotation_notified() => {
-                    tracing::debug!("Rotation timer reset");
-                    continue;
+                Err(e) => {
+                    tracing::error!("Cleanup: failed to expire messages: {e}");
                 }
             }
         }

--- a/crates/herald-server/src/main.rs
+++ b/crates/herald-server/src/main.rs
@@ -37,6 +37,7 @@ async fn main() {
     // Build app
     let state = AppState::new(pool, admin_token);
     herald_server::start_rotation_task(state.clone());
+    herald_server::start_cleanup_task(state.clone());
     let app = build_router(state);
 
     // Start server


### PR DESCRIPTION
## Description

Add real-time countdown refresh, configurable zero behavior, and periodic soft-delete cleanup for expired queue items.

### What's included

- **Countdown 1-second refresh**: When the currently displayed queue item is a countdown, a secondary 1-second interval broadcasts updated board states so all viewers see the countdown tick in real time. The refresh runs in parallel with the main rotation timer via `tokio::select!` and exits cleanly when the rotation timer fires.
- **Zero behavior handling**: When a countdown reaches zero, the configured `ZeroBehavior` is applied:
  - `ShowZero` — displays 00:00:00 until the next rotation tick
  - `ShowMessage` — same as ShowZero for now (custom grid override noted as TODO)
  - `Remove` — soft-deletes the countdown and immediately advances to the next queue item
  - `Pause` — stops rotation and holds on the zero display until an admin resets (config change, queue mutation)
- **Soft-delete schema**: New migration adds `deleted_at` column to messages and countdowns. Expired items are marked rather than hard-deleted, preserving history. All list/queue queries filter on `WHERE deleted_at IS NULL`.
- **Periodic cleanup task**: A 60-second background task soft-expires messages past their `expires_at` time. If the currently-displayed item is expired, the rotation timer is reset to trigger an immediate advance.
- **Rotation task restructured**: The rotation task now detects whether the current item is a message or countdown and enters the appropriate mode (normal rotation vs. countdown refresh).

## Related Issues

Closes #23 
Closes #24 
Closes #25 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [ ] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)