### PR TITLE
feat: add text-based message creation API with auto grid rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default "HERALD" splash screen displayed when the queue is empty
 - Rotation metadata (`queue_info`) broadcast alongside every board update for viewer status bars
 - Rotation progress display in CLI status bar ("Item 2/5 · Next in 18s" or "Countdown active")
+- Text-based message creation via `POST /api/messages` with `{"text": "..."}` — auto-renders to 6×22 grid with word-wrapping, alignment, and character normalization
+- Dual-mode message API: accepts either `text` (auto-rendered) or `grid` (raw 6×22) for both create and update
+- Source text preservation on messages for round-trip editing and alignment reflow

--- a/crates/herald-common/src/lib.rs
+++ b/crates/herald-common/src/lib.rs
@@ -56,4 +56,126 @@ mod tests {
             }
         }
     }
+
+    /// Extract all chars from a grid row.
+    fn row_text(grid: &Grid, row: usize) -> String {
+        grid.0[row]
+            .iter()
+            .filter_map(|c| match c {
+                CellContent::Char(ch) => Some(*ch),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Extract chars from a grid row preserving blanks as spaces (trimmed at end).
+    fn row_text_with_blanks(grid: &Grid, row: usize) -> String {
+        let s: String = grid.0[row]
+            .iter()
+            .map(|c| match c {
+                CellContent::Char(ch) => *ch,
+                _ => ' ',
+            })
+            .collect();
+        s.trim_end().to_string()
+    }
+
+    #[test]
+    fn from_text_simple_centered() {
+        let grid = Grid::from_text("HELLO", HAlign::Center, VAlign::Middle).unwrap();
+        // "HELLO" is 5 chars, centered in 22 cols → starts at col 8
+        // Vertically middle with 1 line in 6 rows → row 2
+        assert_eq!(row_text(&grid, 2), "HELLO");
+        // Other rows should be blank
+        for r in [0, 1, 3, 4, 5] {
+            assert_eq!(row_text(&grid, r), "");
+        }
+    }
+
+    #[test]
+    fn from_text_left_aligned() {
+        let grid = Grid::from_text("HI", HAlign::Left, VAlign::Top).unwrap();
+        let row = row_text_with_blanks(&grid, 0);
+        assert!(row.starts_with("HI"));
+    }
+
+    #[test]
+    fn from_text_right_aligned() {
+        let grid = Grid::from_text("HI", HAlign::Right, VAlign::Top).unwrap();
+        let row = row_text_with_blanks(&grid, 0);
+        assert!(row.ends_with("HI"));
+    }
+
+    #[test]
+    fn from_text_uppercases() {
+        let grid = Grid::from_text("hello", HAlign::Center, VAlign::Middle).unwrap();
+        assert_eq!(row_text(&grid, 2), "HELLO");
+    }
+
+    #[test]
+    fn from_text_word_wraps() {
+        // "AAAA BBBB CCCC DDDD EEEE FFFF" → wraps to multiple lines
+        let grid = Grid::from_text(
+            "AAAA BBBB CCCC DDDD EEEE FFFF",
+            HAlign::Center,
+            VAlign::Top,
+        )
+        .unwrap();
+        // First line should have some words, second line the rest
+        let line0 = row_text(&grid, 0);
+        let line1 = row_text(&grid, 1);
+        assert!(!line0.is_empty());
+        assert!(!line1.is_empty());
+    }
+
+    #[test]
+    fn from_text_explicit_newlines() {
+        let grid = Grid::from_text("LINE ONE\nLINE TWO", HAlign::Center, VAlign::Top).unwrap();
+        // Spaces are valid chars on the board, so row_text includes them
+        assert_eq!(row_text(&grid, 0), "LINE ONE");
+        assert_eq!(row_text(&grid, 1), "LINE TWO");
+    }
+
+    #[test]
+    fn from_text_overflow_returns_error() {
+        // 7 lines should fail (board has 6 rows)
+        let text = "A\nB\nC\nD\nE\nF\nG";
+        let result = Grid::from_text(text, HAlign::Center, VAlign::Top);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_text_empty_returns_blank_grid() {
+        let grid = Grid::from_text("", HAlign::Center, VAlign::Middle).unwrap();
+        assert_eq!(grid, Grid::blank());
+    }
+
+    #[test]
+    fn from_text_normalizes_unsupported_chars() {
+        // Unsupported chars become blanks (spaces)
+        let grid = Grid::from_text("HI™THERE", HAlign::Left, VAlign::Top).unwrap();
+        let row = row_text(&grid, 0);
+        // ™ is unsupported → space → words become "HI THERE"
+        assert!(row.contains("HI"));
+        assert!(row.contains("THERE"));
+    }
+
+    #[test]
+    fn from_text_long_word_hard_splits() {
+        let long = "A".repeat(30); // longer than 22 cols
+        let grid = Grid::from_text(&long, HAlign::Left, VAlign::Top).unwrap();
+        // Should be split into 22 + 8 chars across 2 rows
+        assert_eq!(row_text(&grid, 0).len(), 22);
+        assert_eq!(row_text(&grid, 1).len(), 8);
+    }
+
+    #[test]
+    fn from_text_max_rows_ok() {
+        // Exactly 6 lines should succeed
+        let text = "A\nB\nC\nD\nE\nF";
+        let grid = Grid::from_text(text, HAlign::Center, VAlign::Top).unwrap();
+        for r in 0..6 {
+            assert!(!row_text(&grid, r).is_empty());
+        }
+    }
 }

--- a/crates/herald-common/src/lib.rs
+++ b/crates/herald-common/src/lib.rs
@@ -115,12 +115,8 @@ mod tests {
     #[test]
     fn from_text_word_wraps() {
         // "AAAA BBBB CCCC DDDD EEEE FFFF" → wraps to multiple lines
-        let grid = Grid::from_text(
-            "AAAA BBBB CCCC DDDD EEEE FFFF",
-            HAlign::Center,
-            VAlign::Top,
-        )
-        .unwrap();
+        let grid =
+            Grid::from_text("AAAA BBBB CCCC DDDD EEEE FFFF", HAlign::Center, VAlign::Top).unwrap();
         // First line should have some words, second line the rest
         let line0 = row_text(&grid, 0);
         let line1 = row_text(&grid, 1);

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -81,6 +81,138 @@ impl Grid {
         }
         Ok(())
     }
+
+    /// Normalize a character to the split-flap character set.
+    /// Returns `None` for unsupported characters (rendered as blank).
+    fn normalize_char(ch: char) -> Option<char> {
+        let upper = ch.to_uppercase().next().unwrap_or(ch);
+        match upper {
+            'A'..='Z' | '0'..='9' | ' ' => Some(upper),
+            '!' | '@' | '#' | '$' | '%' | '&' | '(' | ')' | '-' | '+' | '=' | ';' | ':'
+            | '\'' | '"' | ',' | '.' | '/' | '?' | '*' => Some(upper),
+            // Common typographic mappings
+            '\u{2019}' | '\u{2018}' => Some('\''), // smart quotes
+            '\u{201C}' | '\u{201D}' => Some('"'),  // smart double quotes
+            '\u{2014}' | '\u{2013}' => Some('-'),   // em/en dash
+            '\u{2026}' => Some('.'),                 // ellipsis → period
+            _ => None,                               // unsupported → blank
+        }
+    }
+
+    /// Word-wrap text into lines that fit within BOARD_COLS.
+    fn wrap_text(text: &str) -> Vec<Vec<char>> {
+        let mut lines: Vec<Vec<char>> = Vec::new();
+
+        for input_line in text.split('\n') {
+            let normalized: Vec<char> = input_line
+                .chars()
+                .map(|c| Self::normalize_char(c).unwrap_or(' '))
+                .collect();
+
+            // Collapse multiple spaces
+            let collapsed: Vec<char> = {
+                let mut result = Vec::new();
+                let mut prev_space = false;
+                for &ch in &normalized {
+                    if ch == ' ' {
+                        if !prev_space && !result.is_empty() {
+                            result.push(' ');
+                        }
+                        prev_space = true;
+                    } else {
+                        result.push(ch);
+                        prev_space = false;
+                    }
+                }
+                // Trim trailing space
+                if result.last() == Some(&' ') {
+                    result.pop();
+                }
+                result
+            };
+
+            if collapsed.is_empty() {
+                lines.push(Vec::new());
+                continue;
+            }
+
+            // Split into words
+            let words: Vec<&[char]> = collapsed
+                .split(|c| *c == ' ')
+                .filter(|w| !w.is_empty())
+                .collect();
+
+            let mut current_line: Vec<char> = Vec::new();
+            for word in words {
+                if word.len() > BOARD_COLS {
+                    // Hard-split long words
+                    if !current_line.is_empty() {
+                        lines.push(current_line);
+                        current_line = Vec::new();
+                    }
+                    for chunk in word.chunks(BOARD_COLS) {
+                        lines.push(chunk.to_vec());
+                    }
+                } else if current_line.is_empty() {
+                    current_line = word.to_vec();
+                } else if current_line.len() + 1 + word.len() <= BOARD_COLS {
+                    current_line.push(' ');
+                    current_line.extend_from_slice(word);
+                } else {
+                    lines.push(current_line);
+                    current_line = word.to_vec();
+                }
+            }
+            if !current_line.is_empty() {
+                lines.push(current_line);
+            }
+        }
+
+        lines
+    }
+
+    /// Align a line of characters within a row based on horizontal alignment.
+    fn place_line(row: &mut [CellContent], chars: &[char], h_align: HAlign) {
+        let len = chars.len().min(BOARD_COLS);
+        let start = match h_align {
+            HAlign::Left => 0,
+            HAlign::Center => (BOARD_COLS - len) / 2,
+            HAlign::Right => BOARD_COLS - len,
+        };
+        for (i, &ch) in chars[..len].iter().enumerate() {
+            row[start + i] = CellContent::Char(ch);
+        }
+    }
+
+    /// Build a grid from a text string, with word-wrapping, normalization, and alignment.
+    ///
+    /// Returns an error if the text requires more than BOARD_ROWS lines after wrapping.
+    pub fn from_text(text: &str, h_align: HAlign, v_align: VAlign) -> Result<Self, String> {
+        let lines = Self::wrap_text(text);
+
+        if lines.len() > BOARD_ROWS {
+            return Err(format!(
+                "text requires {} lines but the board only has {BOARD_ROWS} rows",
+                lines.len()
+            ));
+        }
+
+        let mut grid = Self::blank();
+
+        let start_row = match v_align {
+            VAlign::Top => 0,
+            VAlign::Middle => (BOARD_ROWS - lines.len()) / 2,
+        };
+
+        for (i, line) in lines.iter().enumerate() {
+            let row_idx = start_row + i;
+            if row_idx < BOARD_ROWS {
+                Self::place_line(&mut grid.0[row_idx], line, h_align);
+            }
+        }
+
+        Ok(grid)
+    }
 }
 
 impl Default for Grid {
@@ -96,6 +228,8 @@ impl Default for Grid {
 pub struct Message {
     pub id: Uuid,
     pub grid: Grid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_text: Option<String>,
     pub h_align: HAlign,
     pub v_align: VAlign,
     pub queue_position: i64,
@@ -227,9 +361,11 @@ pub enum ClientMessage {
 // ── API request/response DTOs ─────────────────────────────────────
 
 /// Request body for POST /api/messages.
+/// Accepts either `text` (auto-rendered) or `grid` (raw 6×22), but not both.
 #[derive(Debug, Deserialize)]
 pub struct CreateMessageRequest {
-    pub grid: Grid,
+    pub text: Option<String>,
+    pub grid: Option<Grid>,
     #[serde(default)]
     pub h_align: HAlign,
     #[serde(default)]
@@ -239,8 +375,10 @@ pub struct CreateMessageRequest {
 }
 
 /// Request body for PUT /api/messages/:id.
+/// Accepts either `text` or `grid` to replace the content.
 #[derive(Debug, Deserialize)]
 pub struct UpdateMessageRequest {
+    pub text: Option<String>,
     pub grid: Option<Grid>,
     pub h_align: Option<HAlign>,
     pub v_align: Option<VAlign>,

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -88,14 +88,14 @@ impl Grid {
         let upper = ch.to_uppercase().next().unwrap_or(ch);
         match upper {
             'A'..='Z' | '0'..='9' | ' ' => Some(upper),
-            '!' | '@' | '#' | '$' | '%' | '&' | '(' | ')' | '-' | '+' | '=' | ';' | ':'
-            | '\'' | '"' | ',' | '.' | '/' | '?' | '*' => Some(upper),
+            '!' | '@' | '#' | '$' | '%' | '&' | '(' | ')' | '-' | '+' | '=' | ';' | ':' | '\''
+            | '"' | ',' | '.' | '/' | '?' | '*' => Some(upper),
             // Common typographic mappings
             '\u{2019}' | '\u{2018}' => Some('\''), // smart quotes
             '\u{201C}' | '\u{201D}' => Some('"'),  // smart double quotes
-            '\u{2014}' | '\u{2013}' => Some('-'),   // em/en dash
-            '\u{2026}' => Some('.'),                 // ellipsis → period
-            _ => None,                               // unsupported → blank
+            '\u{2014}' | '\u{2013}' => Some('-'),  // em/en dash
+            '\u{2026}' => Some('.'),               // ellipsis → period
+            _ => None,                             // unsupported → blank
         }
     }
 

--- a/crates/herald-server/migrations/003_source_text.sql
+++ b/crates/herald-server/migrations/003_source_text.sql
@@ -1,0 +1,2 @@
+-- Add source_text column to preserve original text input for reflowing
+ALTER TABLE messages ADD COLUMN source_text TEXT;

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -148,8 +148,9 @@ fn resolve_update_content(
     }
 
     // Alignment-only update: reflow if source_text exists
-    if (req.h_align.is_some() || req.v_align.is_some()) && existing.source_text.is_some() {
-        let text = existing.source_text.as_ref().unwrap();
+    if let Some(text) = &existing.source_text
+        && (req.h_align.is_some() || req.v_align.is_some())
+    {
         let h_align = req.h_align.unwrap_or(existing.h_align);
         let v_align = req.v_align.unwrap_or(existing.v_align);
         let grid = Grid::from_text(text, h_align, v_align).map_err(ApiError::BadRequest)?;

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -17,8 +17,8 @@ pub async fn create(
     // Resolve grid from text or raw grid (exactly one must be provided)
     let (grid, source_text) = match (req.text, req.grid) {
         (Some(text), None) => {
-            let grid = Grid::from_text(&text, req.h_align, req.v_align)
-                .map_err(ApiError::BadRequest)?;
+            let grid =
+                Grid::from_text(&text, req.h_align, req.v_align).map_err(ApiError::BadRequest)?;
             (grid, Some(text))
         }
         (None, Some(grid)) => {

--- a/crates/herald-server/src/api/messages.rs
+++ b/crates/herald-server/src/api/messages.rs
@@ -14,8 +14,28 @@ pub async fn create(
     State(state): State<AppState>,
     Json(req): Json<CreateMessageRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // Validate grid dimensions
-    req.grid.validate().map_err(ApiError::BadRequest)?;
+    // Resolve grid from text or raw grid (exactly one must be provided)
+    let (grid, source_text) = match (req.text, req.grid) {
+        (Some(text), None) => {
+            let grid = Grid::from_text(&text, req.h_align, req.v_align)
+                .map_err(ApiError::BadRequest)?;
+            (grid, Some(text))
+        }
+        (None, Some(grid)) => {
+            grid.validate().map_err(ApiError::BadRequest)?;
+            (grid, None)
+        }
+        (Some(_), Some(_)) => {
+            return Err(ApiError::BadRequest(
+                "provide either 'text' or 'grid', not both".to_string(),
+            ));
+        }
+        (None, None) => {
+            return Err(ApiError::BadRequest(
+                "provide either 'text' or 'grid'".to_string(),
+            ));
+        }
+    };
 
     let position = match req.queue_position {
         Some(p) => p,
@@ -24,7 +44,8 @@ pub async fn create(
 
     let msg = Message {
         id: Uuid::new_v4(),
-        grid: req.grid,
+        grid,
+        source_text,
         h_align: req.h_align,
         v_align: req.v_align,
         queue_position: position,
@@ -63,12 +84,26 @@ pub async fn update(
     Path(id): Path<String>,
     Json(req): Json<UpdateMessageRequest>,
 ) -> Result<Json<Message>, ApiError> {
-    // Validate grid if provided
+    // Cannot provide both text and grid
+    if req.text.is_some() && req.grid.is_some() {
+        return Err(ApiError::BadRequest(
+            "provide either 'text' or 'grid', not both".to_string(),
+        ));
+    }
+
+    // Validate grid if provided directly
     if let Some(ref grid) = req.grid {
         grid.validate().map_err(ApiError::BadRequest)?;
     }
 
-    let updated = db::update_message(state.pool(), &id, &req).await?;
+    // If text is provided, or alignment changed with existing source_text, recompute grid
+    let existing = db::get_message(state.pool(), &id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("message {id} not found")))?;
+
+    let resolved = resolve_update_content(&existing, &req)?;
+
+    let updated = db::update_message(state.pool(), &id, &req, resolved.as_ref()).await?;
     if !updated {
         return Err(ApiError::NotFound(format!("message {id} not found")));
     }
@@ -80,6 +115,51 @@ pub async fn update(
     state.notify_board_update().await;
 
     Ok(Json(msg))
+}
+
+/// Resolved content for an update (grid + source_text).
+pub struct ResolvedContent {
+    pub grid: Grid,
+    pub source_text: Option<String>,
+}
+
+/// If the update changes text or alignment for a text-based message, recompute the grid.
+fn resolve_update_content(
+    existing: &Message,
+    req: &UpdateMessageRequest,
+) -> Result<Option<ResolvedContent>, ApiError> {
+    if let Some(ref text) = req.text {
+        // Explicit text update — recompute grid
+        let h_align = req.h_align.unwrap_or(existing.h_align);
+        let v_align = req.v_align.unwrap_or(existing.v_align);
+        let grid = Grid::from_text(text, h_align, v_align).map_err(ApiError::BadRequest)?;
+        return Ok(Some(ResolvedContent {
+            grid,
+            source_text: Some(text.clone()),
+        }));
+    }
+
+    if let Some(ref grid) = req.grid {
+        // Explicit grid update — clear source_text
+        return Ok(Some(ResolvedContent {
+            grid: grid.clone(),
+            source_text: None,
+        }));
+    }
+
+    // Alignment-only update: reflow if source_text exists
+    if (req.h_align.is_some() || req.v_align.is_some()) && existing.source_text.is_some() {
+        let text = existing.source_text.as_ref().unwrap();
+        let h_align = req.h_align.unwrap_or(existing.h_align);
+        let v_align = req.v_align.unwrap_or(existing.v_align);
+        let grid = Grid::from_text(text, h_align, v_align).map_err(ApiError::BadRequest)?;
+        return Ok(Some(ResolvedContent {
+            grid,
+            source_text: Some(text.clone()),
+        }));
+    }
+
+    Ok(None)
 }
 
 pub async fn delete(

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -36,11 +36,12 @@ pub async fn create_message(pool: &SqlitePool, msg: &Message) -> Result<(), sqlx
     let expires = msg.expires_at.map(|d| d.to_rfc3339());
 
     sqlx::query(
-        "INSERT INTO messages (id, grid, h_align, v_align, queue_position, created_at, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO messages (id, grid, source_text, h_align, v_align, queue_position, created_at, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&id)
     .bind(&grid_json)
+    .bind(&msg.source_text)
     .bind(&h_align)
     .bind(&v_align)
     .bind(msg.queue_position)
@@ -73,14 +74,25 @@ pub async fn update_message(
     pool: &SqlitePool,
     id: &str,
     req: &UpdateMessageRequest,
+    resolved: Option<&crate::api::messages::ResolvedContent>,
 ) -> Result<bool, sqlx::Error> {
     // Build dynamic update
     let mut sets = Vec::new();
     let mut values: Vec<String> = Vec::new();
+    // Track which sets are null-valued for expires_at handling
+    let mut null_indices: Vec<usize> = Vec::new();
 
-    if let Some(ref grid) = req.grid {
+    if let Some(resolved) = resolved {
         sets.push("grid = ?");
-        values.push(serde_json::to_string(grid).unwrap());
+        values.push(serde_json::to_string(&resolved.grid).unwrap());
+        sets.push("source_text = ?");
+        match &resolved.source_text {
+            Some(t) => values.push(t.clone()),
+            None => {
+                null_indices.push(values.len());
+                values.push(String::new());
+            }
+        }
     }
     if let Some(ref h) = req.h_align {
         sets.push("h_align = ?");
@@ -96,10 +108,13 @@ pub async fn update_message(
     }
     if let Some(ref exp) = req.expires_at {
         sets.push("expires_at = ?");
-        values.push(match exp {
-            Some(d) => d.to_rfc3339(),
-            None => String::new(),
-        });
+        match exp {
+            Some(d) => values.push(d.to_rfc3339()),
+            None => {
+                null_indices.push(values.len());
+                values.push(String::new());
+            }
+        }
     }
 
     if sets.is_empty() {
@@ -109,9 +124,8 @@ pub async fn update_message(
     let sql = format!("UPDATE messages SET {} WHERE id = ?", sets.join(", "));
     let mut query = sqlx::query(&sql);
 
-    for val in &values {
-        // Handle the expires_at = null case
-        if val.is_empty() && sets.iter().any(|s| s.contains("expires_at")) {
+    for (i, val) in values.iter().enumerate() {
+        if null_indices.contains(&i) {
             query = query.bind(None::<String>);
         } else {
             query = query.bind(val);
@@ -134,6 +148,7 @@ pub async fn delete_message(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::E
 fn row_to_message(row: &sqlx::sqlite::SqliteRow) -> Message {
     let id_str: String = row.get("id");
     let grid_json: String = row.get("grid");
+    let source_text: Option<String> = row.get("source_text");
     let h_align_str: String = row.get("h_align");
     let v_align_str: String = row.get("v_align");
     let created_str: String = row.get("created_at");
@@ -142,6 +157,7 @@ fn row_to_message(row: &sqlx::sqlite::SqliteRow) -> Message {
     Message {
         id: uuid::Uuid::parse_str(&id_str).unwrap(),
         grid: serde_json::from_str(&grid_json).unwrap(),
+        source_text,
         h_align: serde_json::from_str(&format!("\"{h_align_str}\"")).unwrap(),
         v_align: serde_json::from_str(&format!("\"{v_align_str}\"")).unwrap(),
         queue_position: row.get("queue_position"),

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -42,24 +42,6 @@ async fn json_body(response: axum::response::Response) -> Value {
     serde_json::from_slice(&body).unwrap()
 }
 
-/// Build a grid with text in the first row.
-fn text_grid(text: &str) -> Value {
-    let mut grid_data = Vec::new();
-    for r in 0..6 {
-        let mut row = Vec::new();
-        for c in 0..22 {
-            if r == 0 && c < text.len() {
-                let ch = text.chars().nth(c).unwrap();
-                row.push(json!({"type": "char", "value": ch.to_string()}));
-            } else {
-                row.push(json!({"type": "blank", "value": null}));
-            }
-        }
-        grid_data.push(row);
-    }
-    json!(grid_data)
-}
-
 // ── Health ────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -133,7 +115,7 @@ async fn create_message_returns_201() {
     let (app, db_path) = test_app().await;
 
     let body = json!({
-        "grid": text_grid("HELLO WORLD"),
+        "text": "HELLO WORLD",
         "h_align": "center",
         "v_align": "middle"
     });
@@ -172,6 +154,20 @@ async fn create_message_invalid_grid_returns_400() {
 
     let body = json!({ "grid": bad_grid });
 
+    let response = app
+        .clone()
+        .oneshot(
+            authed_request("POST", "/api/messages")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Neither text nor grid → 400
+    let body = json!({ "h_align": "center" });
     let response = app
         .oneshot(
             authed_request("POST", "/api/messages")
@@ -212,7 +208,7 @@ async fn message_crud_full_lifecycle() {
 
     // CREATE
     let create_body = json!({
-        "grid": text_grid("TEST MESSAGE"),
+        "text": "TEST MESSAGE",
         "h_align": "left"
     });
     let response = app
@@ -461,7 +457,7 @@ async fn queue_merged_and_reorder() {
 
     // Create a message
     let msg_body = json!({
-        "grid": text_grid("MSG ONE"),
+        "text": "MSG ONE",
     });
     let response = app
         .clone()
@@ -529,7 +525,7 @@ async fn queue_reorder_incomplete_ids_returns_400() {
     let (app, db_path) = test_app().await;
 
     // Create a message
-    let msg_body = json!({ "grid": text_grid("TEST") });
+    let msg_body = json!({ "text": "TEST" });
     app.clone()
         .oneshot(
             authed_request("POST", "/api/messages")
@@ -759,7 +755,7 @@ async fn ws_broadcast_on_message_create() {
         .post(format!("http://{addr}/api/messages"))
         .header("authorization", format!("Bearer {TEST_TOKEN}"))
         .json(&serde_json::json!({
-            "grid": text_grid("BROADCAST"),
+            "text": "BROADCAST",
             "h_align": "center",
             "v_align": "middle"
         }))
@@ -820,7 +816,7 @@ async fn ws_broadcast_on_message_delete() {
         .post(format!("http://{addr}/api/messages"))
         .header("authorization", format!("Bearer {TEST_TOKEN}"))
         .json(&serde_json::json!({
-            "grid": text_grid("DELETE ME"),
+            "text": "DELETE ME",
             "h_align": "center",
             "v_align": "middle"
         }))
@@ -1020,7 +1016,7 @@ async fn ws_initial_state_with_existing_message() {
         .post(format!("http://{addr}/api/messages"))
         .header("authorization", format!("Bearer {TEST_TOKEN}"))
         .json(&serde_json::json!({
-            "grid": text_grid("INITIAL"),
+            "text": "INITIAL",
             "h_align": "center",
             "v_align": "middle"
         }))
@@ -1103,7 +1099,7 @@ async fn rotation_advance_cycles_through_queue() {
             .post(format!("http://{addr}/api/messages"))
             .header("authorization", format!("Bearer {TEST_TOKEN}"))
             .json(&serde_json::json!({
-                "grid": text_grid(label),
+                "text": label,
                 "h_align": "center",
                 "v_align": "middle"
             }))
@@ -1186,7 +1182,7 @@ async fn rotation_skips_and_deletes_expired_messages() {
         .post(format!("http://{addr}/api/messages"))
         .header("authorization", format!("Bearer {TEST_TOKEN}"))
         .json(&serde_json::json!({
-            "grid": text_grid("KEEP"),
+            "text": "KEEP",
             "h_align": "center",
             "v_align": "middle"
         }))
@@ -1204,7 +1200,7 @@ async fn rotation_skips_and_deletes_expired_messages() {
         .post(format!("http://{addr}/api/messages"))
         .header("authorization", format!("Bearer {TEST_TOKEN}"))
         .json(&serde_json::json!({
-            "grid": text_grid("EXPIRED"),
+            "text": "EXPIRED",
             "h_align": "center",
             "v_align": "middle",
             "expires_at": "2020-01-01T00:00:00Z"
@@ -1271,7 +1267,7 @@ async fn rotation_all_expired_results_in_empty_board() {
             .post(format!("http://{addr}/api/messages"))
             .header("authorization", format!("Bearer {TEST_TOKEN}"))
             .json(&serde_json::json!({
-                "grid": text_grid(label),
+                "text": label,
                 "h_align": "center",
                 "v_align": "middle",
                 "expires_at": "2020-01-01T00:00:00Z"


### PR DESCRIPTION
## Description

Simplify the message creation API to accept plain text instead of requiring a full 6×22 grid of cells.

Previously, pushing a message to the board required constructing a 132-element nested JSON grid — impractical for curl or any quick integration. Now you can simply send {"text": "HELLO WORLD"} and the server handles word-wrapping, uppercase normalization, character mapping, and alignment automatically.

### What's included

- **Grid::from_text() in herald-common** — converts a text string to a 6×22 board grid with word-wrapping at column boundaries, automatic uppercase conversion, typographic character normalization (smart quotes, em dashes, etc.), and configurable horizontal/vertical alignment
- **Dual-mode API** — POST /api/messages and PUT /api/messages/:id now accept either 	ext (auto-rendered) or grid (raw 6×22) — exactly one is required. Providing both or neither returns 400
- **Source text preservation** — when a message is created via 	ext, the original string is persisted so alignment changes on update trigger a reflow rather than being silently ignored
- **Overflow protection** — text that exceeds 6 rows after wrapping returns 400 Bad Request instead of silently truncating
- **11 unit tests** for Grid::from_text() covering centering, alignment, word-wrapping, newlines, overflow, normalization, and long-word hard-splitting
- **Updated integration tests** — all 29 API tests now use the 	ext field, validating the new flow end-to-end

## Related Issues

<!-- No specific issue — this was identified during a live demo as a usability improvement -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)