### PR TITLE
feat: add split-flap flip animation with cascade stagger to CLI viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text-based message creation via `POST /api/messages` with `{"text": "..."}` — auto-renders to 6×22 grid with word-wrapping, alignment, and character normalization
 - Dual-mode message API: accepts either `text` (auto-rendered) or `grid` (raw 6×22) for both create and update
 - Source text preservation on messages for round-trip editing and alignment reflow
+- Split-flap flip animation in `herald watch` — tiles cycle through intermediate characters with a "─X─" mid-flip visual when the board transitions between messages
+- Left-to-right cascade stagger effect: columns start their flip animation with a 20ms delay between each, creating the characteristic split-flap wave
+- Time-based animation engine with configurable step duration (50ms/char) and column stagger (20ms), smooth mid-animation restarts when new board updates arrive

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -8,8 +8,18 @@ use crossterm::{
 };
 use ratatui::prelude::*;
 
-use crate::ui::{BoardWidget, StatusBar};
+use crate::ui::animation::BoardAnimation;
+use crate::ui::{BoardWidget, DisplayGrid, StatusBar};
 use crate::ws_client::WsClient;
+
+/// Default duration for each character step in the cycling animation.
+const STEP_DURATION: Duration = Duration::from_millis(50);
+
+/// Default cascade delay between columns.
+const STAGGER_PER_COLUMN: Duration = Duration::from_millis(20);
+
+/// Minimum tick interval during animation for smooth rendering.
+const ANIMATION_TICK: Duration = Duration::from_millis(20);
 
 pub async fn run(server: String, fps: u16) -> Result<(), Box<dyn std::error::Error>> {
     let (client, mut board_rx, mut conn_rx, mut queue_rx) = WsClient::new(server.clone());
@@ -49,11 +59,15 @@ async fn run_tui(
     server_url: &str,
     fps: u16,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let tick_duration = Duration::from_millis(1000 / fps.max(1) as u64);
+    let normal_tick = Duration::from_millis(1000 / fps.max(1) as u64);
     let mut last_update: Option<Instant> = None;
 
+    // Animation state
+    let mut current_display = DisplayGrid::from_board_state(&board_rx.borrow());
+    let mut animation: Option<BoardAnimation> = None;
+
     let draw = |frame: &mut ratatui::Frame,
-                board_state: &herald_common::BoardState,
+                display: &DisplayGrid,
                 conn_state: &crate::ws_client::ConnectionState,
                 queue_info: &crate::ws_client::QueueInfoState,
                 server_url: &str,
@@ -61,7 +75,7 @@ async fn run_tui(
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        frame.render_widget(BoardWidget::new(board_state), chunks[0]);
+        frame.render_widget(BoardWidget::new(display), chunks[0]);
         frame.render_widget(
             StatusBar::new(conn_state, server_url, last_update, queue_info),
             chunks[1],
@@ -69,13 +83,12 @@ async fn run_tui(
     };
 
     // Initial draw
-    let board_state = board_rx.borrow().clone();
     let conn_state = conn_rx.borrow().clone();
     let queue_info = queue_rx.borrow().clone();
     terminal.draw(|frame| {
         draw(
             frame,
-            &board_state,
+            &current_display,
             &conn_state,
             &queue_info,
             server_url,
@@ -84,41 +97,74 @@ async fn run_tui(
     })?;
 
     loop {
+        // Use a shorter tick when animating for smooth rendering
+        let tick_duration = if animation.is_some() {
+            ANIMATION_TICK.min(normal_tick)
+        } else {
+            normal_tick
+        };
+
         tokio::select! {
             result = board_rx.changed() => {
                 if result.is_err() {
                     break;
                 }
                 last_update = Some(Instant::now());
-                let board_state = board_rx.borrow().clone();
+                let new_board = board_rx.borrow().clone();
+
+                // Start animation from the currently visible display state
+                let from_display = if let Some(ref anim) = animation {
+                    anim.sample(Instant::now())
+                } else {
+                    current_display.clone()
+                };
+
+                animation = Some(BoardAnimation::new(
+                    &from_display,
+                    &new_board,
+                    STEP_DURATION,
+                    STAGGER_PER_COLUMN,
+                ));
+
+                // Render immediately with the new animation's first frame
+                let now = Instant::now();
+                current_display = animation.as_ref().unwrap().sample(now);
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &board_state, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = conn_rx.changed() => {
-                let board_state = board_rx.borrow().clone();
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &board_state, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = queue_rx.changed() => {
-                let board_state = board_rx.borrow().clone();
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &board_state, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = tokio::time::sleep(tick_duration) => {
-                let board_state = board_rx.borrow().clone();
+                // Advance animation if active
+                if let Some(ref anim) = animation {
+                    let now = Instant::now();
+                    current_display = anim.sample(now);
+
+                    if anim.is_complete(now) {
+                        // Animation finished — settle on the final target state
+                        animation = None;
+                    }
+                }
+
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &board_state, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
                 })?;
 
                 if event::poll(Duration::from_millis(0))? {

--- a/crates/herald-cli/src/ui/animation.rs
+++ b/crates/herald-cli/src/ui/animation.rs
@@ -1,0 +1,507 @@
+use std::time::{Duration, Instant};
+
+use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent};
+
+use super::display_state::{CellDisplayState, DisplayGrid};
+
+/// The ordered character cycle for split-flap boards.
+/// Space (blank) at index 0, then A-Z, 0-9, and punctuation.
+pub const CHAR_SET: &[char] = &[
+    ' ', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+    'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '!',
+    '@', '#', '$', '%', '&', '(', ')', '-', '+', '=', ';', ':', '\'', '"', ',', '.', '/', '?', '*',
+];
+
+/// Find a character's position in `CHAR_SET`.
+pub fn char_index(ch: char) -> Option<usize> {
+    CHAR_SET.iter().position(|&c| c == ch)
+}
+
+/// Compute the intermediate characters when cycling forward through `CHAR_SET`.
+///
+/// Always cycles forward (real split-flap boards go one direction).
+/// Returns the sequence excluding `from` but including `to`.
+/// If `from == to`, returns empty.
+pub fn cycling_steps(from: char, to: char) -> Vec<char> {
+    if from == to {
+        return Vec::new();
+    }
+
+    let from_idx = match char_index(from) {
+        Some(i) => i,
+        None => return vec![to], // unknown char → snap
+    };
+    let to_idx = match char_index(to) {
+        Some(i) => i,
+        None => return vec![to], // unknown target → snap
+    };
+
+    let len = CHAR_SET.len();
+    let mut steps = Vec::new();
+    let mut i = (from_idx + 1) % len;
+    loop {
+        steps.push(CHAR_SET[i]);
+        if i == to_idx {
+            break;
+        }
+        i = (i + 1) % len;
+    }
+    steps
+}
+
+/// Extract the displayable character from a `CellDisplayState`.
+fn display_char(state: &CellDisplayState) -> Option<char> {
+    match state {
+        CellDisplayState::Normal(CellContent::Char(c)) => Some(*c),
+        CellDisplayState::Normal(CellContent::Blank) => Some(' '),
+        CellDisplayState::Normal(CellContent::Color(_)) => None,
+        CellDisplayState::Flipping(c) => Some(*c),
+    }
+}
+
+/// Map a target `CellContent` to the character used in the char set.
+fn target_char(content: &CellContent) -> Option<char> {
+    match content {
+        CellContent::Char(c) => Some(*c),
+        CellContent::Blank => Some(' '),
+        CellContent::Color(_) => None,
+    }
+}
+
+/// Per-cell animation state.
+struct CellAnimation {
+    /// Characters to cycle through (from `cycling_steps`), including the final target.
+    steps: Vec<char>,
+    /// When this cell's animation was created (used with `delay` to compute start).
+    created_at: Instant,
+    /// Cascade delay before this cell starts cycling.
+    delay: Duration,
+    /// The original character being displayed when animation started.
+    from_char: char,
+    /// The target cell content (for producing the final `CellDisplayState`).
+    target: CellContent,
+}
+
+/// Manages the animation of the full board transitioning from one state to another.
+pub struct BoardAnimation {
+    cells: Vec<Vec<Option<CellAnimation>>>,
+    /// When this animation was created — used as the reference point for sampling.
+    #[allow(dead_code)] // Accessed in tests for deterministic time-based assertions
+    pub(crate) created_at: Instant,
+    step_duration: Duration,
+    /// The target board state (for cells with no animation).
+    target: BoardState,
+}
+
+impl BoardAnimation {
+    /// Create a new board animation transitioning from the current display to a new target.
+    ///
+    /// - `from`: the currently rendered `DisplayGrid` (handles mid-animation restarts)
+    /// - `to`: the new target `BoardState`
+    /// - `step_duration`: time per character step (~50ms)
+    /// - `stagger_per_column`: cascade delay between columns (~20ms)
+    pub fn new(
+        from: &DisplayGrid,
+        to: &BoardState,
+        step_duration: Duration,
+        stagger_per_column: Duration,
+    ) -> Self {
+        let now = Instant::now();
+        let mut cells = Vec::with_capacity(BOARD_ROWS);
+
+        for row in 0..BOARD_ROWS {
+            let mut row_cells = Vec::with_capacity(BOARD_COLS);
+            for col in 0..BOARD_COLS {
+                let from_state = &from.cells[row][col];
+                let to_content = &to.grid.0[row][col];
+
+                let anim = match (display_char(from_state), target_char(to_content)) {
+                    (Some(from_ch), Some(to_ch)) if from_ch != to_ch => {
+                        let steps = cycling_steps(from_ch, to_ch);
+                        Some(CellAnimation {
+                            steps,
+                            created_at: now,
+                            delay: stagger_per_column * col as u32,
+                            from_char: from_ch,
+                            target: *to_content,
+                        })
+                    }
+                    (Some(_from_ch), Some(_to_ch)) => {
+                        // Same character — no animation needed
+                        None
+                    }
+                    (None, _) | (_, None) => {
+                        // Color cells or unknown — snap immediately, no animation
+                        None
+                    }
+                };
+
+                row_cells.push(anim);
+            }
+            cells.push(row_cells);
+        }
+
+        Self {
+            cells,
+            created_at: now,
+            step_duration,
+            target: to.clone(),
+        }
+    }
+
+    /// Sample the animation at a given instant, producing the current `DisplayGrid`.
+    pub fn sample(&self, now: Instant) -> DisplayGrid {
+        let mut grid_cells = Vec::with_capacity(BOARD_ROWS);
+
+        for row in 0..BOARD_ROWS {
+            let mut row_cells = Vec::with_capacity(BOARD_COLS);
+            for col in 0..BOARD_COLS {
+                let state = match &self.cells[row][col] {
+                    None => {
+                        // No animation — show target content as Normal
+                        CellDisplayState::Normal(self.target.grid.0[row][col])
+                    }
+                    Some(anim) => {
+                        let effective_start = anim.created_at + anim.delay;
+                        if now < effective_start {
+                            // Before cascade delay — show original character
+                            cell_display_for_char(anim.from_char)
+                        } else if anim.steps.is_empty() {
+                            // No steps (same char or snap) — show target
+                            CellDisplayState::Normal(anim.target)
+                        } else {
+                            let elapsed = now.duration_since(effective_start);
+                            let step_idx =
+                                (elapsed.as_nanos() / self.step_duration.as_nanos()) as usize;
+
+                            if step_idx >= anim.steps.len() {
+                                // Animation complete — show final target
+                                CellDisplayState::Normal(anim.target)
+                            } else if step_idx == anim.steps.len() - 1 {
+                                // On the last step — show the target character as Normal
+                                CellDisplayState::Normal(anim.target)
+                            } else {
+                                // Mid-cycling — show as Flipping
+                                CellDisplayState::Flipping(anim.steps[step_idx])
+                            }
+                        }
+                    }
+                };
+                row_cells.push(state);
+            }
+            grid_cells.push(row_cells);
+        }
+
+        DisplayGrid { cells: grid_cells }
+    }
+
+    /// Returns `true` when all cells have finished their animation.
+    pub fn is_complete(&self, now: Instant) -> bool {
+        for row in &self.cells {
+            for anim in row.iter().flatten() {
+                if anim.steps.is_empty() {
+                    continue;
+                }
+                let effective_start = anim.created_at + anim.delay;
+                if now < effective_start {
+                    return false;
+                }
+                let elapsed = now.duration_since(effective_start);
+                let steps_completed = (elapsed.as_nanos() / self.step_duration.as_nanos()) as usize;
+                if steps_completed < anim.steps.len().saturating_sub(1) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// Convert a plain character to a `CellDisplayState::Normal` for display.
+fn cell_display_for_char(ch: char) -> CellDisplayState {
+    if ch == ' ' {
+        CellDisplayState::Normal(CellContent::Blank)
+    } else {
+        CellDisplayState::Normal(CellContent::Char(ch))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use herald_common::{BoardState, Color, Grid};
+
+    #[test]
+    fn test_char_index_space() {
+        assert_eq!(char_index(' '), Some(0));
+    }
+
+    #[test]
+    fn test_char_index_letters() {
+        assert_eq!(char_index('A'), Some(1));
+        assert_eq!(char_index('Z'), Some(26));
+    }
+
+    #[test]
+    fn test_char_index_digits() {
+        assert_eq!(char_index('0'), Some(27));
+        assert_eq!(char_index('9'), Some(36));
+    }
+
+    #[test]
+    fn test_char_index_punctuation() {
+        assert_eq!(char_index('!'), Some(37));
+        assert_eq!(char_index('*'), Some(CHAR_SET.len() - 1));
+    }
+
+    #[test]
+    fn test_char_index_unknown() {
+        assert_eq!(char_index('€'), None);
+    }
+
+    #[test]
+    fn test_cycling_steps_adjacent() {
+        // A→B returns [B]
+        assert_eq!(cycling_steps('A', 'B'), vec!['B']);
+    }
+
+    #[test]
+    fn test_cycling_steps_wrap() {
+        // '*' is last in CHAR_SET, ' ' is first → wraps around
+        assert_eq!(cycling_steps('*', ' '), vec![' ']);
+    }
+
+    #[test]
+    fn test_cycling_steps_same() {
+        assert_eq!(cycling_steps('A', 'A'), Vec::<char>::new());
+    }
+
+    #[test]
+    fn test_cycling_steps_multi() {
+        assert_eq!(cycling_steps('A', 'D'), vec!['B', 'C', 'D']);
+    }
+
+    #[test]
+    fn test_cycling_steps_wrap_multi() {
+        // '?' is second-to-last, ' ' is index 0, 'A' is index 1
+        let steps = cycling_steps('?', 'A');
+        assert_eq!(steps, vec!['*', ' ', 'A']);
+    }
+
+    fn make_board_with_char(ch: char) -> BoardState {
+        let mut state = BoardState::default();
+        state.grid = Grid::blank();
+        state.grid.0[0][0] = CellContent::Char(ch);
+        state
+    }
+
+    fn make_blank_display() -> DisplayGrid {
+        DisplayGrid::blank()
+    }
+
+    #[test]
+    fn test_animation_creates_correctly() {
+        let display = make_blank_display();
+        let target = make_board_with_char('C');
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Cell (0,0) should have animation: ' ' → 'C' = ['A', 'B', 'C']
+        assert!(anim.cells[0][0].is_some());
+        let cell_anim = anim.cells[0][0].as_ref().unwrap();
+        assert_eq!(cell_anim.steps, vec!['A', 'B', 'C']);
+    }
+
+    #[test]
+    fn test_animation_unchanged_cells_no_animation() {
+        let display = make_blank_display();
+        let mut target = BoardState::default();
+        target.grid = Grid::blank(); // all blank — same as display
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // All cells should be None (no animation)
+        for row in &anim.cells {
+            for cell in row {
+                assert!(cell.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn test_animation_sample_before_delay() {
+        let display = make_blank_display();
+        // Put the change at column 5 instead of 0 so there's a cascade delay
+        let mut target_col5 = BoardState::default();
+        target_col5.grid = Grid::blank();
+        target_col5.grid.0[0][5] = CellContent::Char('B');
+
+        let anim = BoardAnimation::new(
+            &display,
+            &target_col5,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Sample immediately — column 5 delay = 100ms, so it should show original (blank)
+        let sampled = anim.sample(anim.created_at + Duration::from_millis(10));
+        match &sampled.cells[0][5] {
+            CellDisplayState::Normal(CellContent::Blank) => {} // correct
+            other => panic!("Expected Normal(Blank) before delay, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_animation_sample_during_cycling() {
+        let display = make_blank_display();
+        let target = make_board_with_char('D');
+        // ' ' → 'D' = ['A', 'B', 'C', 'D'], column 0 has no delay
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // At t=25ms we should be on step 0 ('A'), which is Flipping
+        let sampled = anim.sample(anim.created_at + Duration::from_millis(25));
+        match &sampled.cells[0][0] {
+            CellDisplayState::Flipping('A') => {} // correct
+            other => panic!("Expected Flipping('A'), got {other:?}"),
+        }
+
+        // At t=75ms we should be on step 1 ('B'), which is Flipping
+        let sampled = anim.sample(anim.created_at + Duration::from_millis(75));
+        match &sampled.cells[0][0] {
+            CellDisplayState::Flipping('B') => {} // correct
+            other => panic!("Expected Flipping('B'), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_animation_sample_after_complete() {
+        let display = make_blank_display();
+        let target = make_board_with_char('B');
+        // ' ' → 'B' = ['A', 'B'], column 0 no delay
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // At t=500ms everything should be done
+        let sampled = anim.sample(anim.created_at + Duration::from_millis(500));
+        match &sampled.cells[0][0] {
+            CellDisplayState::Normal(CellContent::Char('B')) => {} // correct
+            other => panic!("Expected Normal(Char('B')), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_animation_is_complete() {
+        let display = make_blank_display();
+        let target = make_board_with_char('B');
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Not complete immediately
+        assert!(!anim.is_complete(anim.created_at));
+
+        // Complete after enough time
+        assert!(anim.is_complete(anim.created_at + Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn test_cascade_ordering() {
+        let display = make_blank_display();
+        let mut target = BoardState::default();
+        target.grid = Grid::blank();
+        target.grid.0[0][0] = CellContent::Char('A');
+        target.grid.0[0][5] = CellContent::Char('A');
+
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Column 0 has delay 0ms, column 5 has delay 100ms
+        let cell0 = anim.cells[0][0].as_ref().unwrap();
+        let cell5 = anim.cells[0][5].as_ref().unwrap();
+        assert!(cell0.delay < cell5.delay);
+        assert_eq!(cell0.delay, Duration::from_millis(0));
+        assert_eq!(cell5.delay, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_color_cells_snap_immediately() {
+        let display = make_blank_display();
+        let mut target = BoardState::default();
+        target.grid = Grid::blank();
+        target.grid.0[0][0] = CellContent::Color(Color::Red);
+
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Color cells should have no animation
+        assert!(anim.cells[0][0].is_none());
+
+        // And should show target immediately
+        let sampled = anim.sample(anim.created_at);
+        match &sampled.cells[0][0] {
+            CellDisplayState::Normal(CellContent::Color(Color::Red)) => {} // correct
+            other => panic!("Expected Normal(Color(Red)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_mid_animation_restart() {
+        // Start an animation ' ' → 'D' at column 0
+        let display = make_blank_display();
+        let target1 = make_board_with_char('D');
+        let anim1 = BoardAnimation::new(
+            &display,
+            &target1,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Sample mid-animation at t=75ms → should be on step 1 ('B')
+        let mid_time = anim1.created_at + Duration::from_millis(75);
+        let mid_display = anim1.sample(mid_time);
+
+        // Now start a NEW animation from mid-display to target 'A'
+        let target2 = make_board_with_char('A');
+        let anim2 = BoardAnimation::new(
+            &mid_display,
+            &target2,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // The animation should start from 'B' (current visible), not from ' '
+        let cell_anim = anim2.cells[0][0].as_ref().unwrap();
+        assert_eq!(cell_anim.from_char, 'B');
+        // 'B' → 'A' forward-cycling should go: C, D, E, ..., Z, 0-9, punctuation, ' ', A
+        assert_eq!(*cell_anim.steps.last().unwrap(), 'A');
+        assert!(cell_anim.steps.len() > 2); // definitely wraps around
+    }
+}

--- a/crates/herald-cli/src/ui/board_widget.rs
+++ b/crates/herald-cli/src/ui/board_widget.rs
@@ -1,11 +1,13 @@
-use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent, Color};
+use herald_common::{BOARD_COLS, BOARD_ROWS, CellContent, Color};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Position, Rect},
-    style::{Color as RatatuiColor, Style},
+    style::{Color as RatatuiColor, Modifier, Style},
     text::Text,
     widgets::{Paragraph, Widget},
 };
+
+use super::display_state::{CellDisplayState, DisplayGrid};
 
 const CELL_WIDTH: u16 = 3;
 const GRID_WIDTH: u16 = BOARD_COLS as u16 * CELL_WIDTH + BOARD_COLS as u16 + 1; // 89
@@ -27,12 +29,12 @@ fn map_color(color: &Color) -> RatatuiColor {
 
 /// A ratatui widget that renders the Herald 6×22 board grid with box-drawing borders.
 pub struct BoardWidget<'a> {
-    board_state: &'a BoardState,
+    display: &'a DisplayGrid,
 }
 
 impl<'a> BoardWidget<'a> {
-    pub fn new(board_state: &'a BoardState) -> Self {
-        Self { board_state }
+    pub fn new(display: &'a DisplayGrid) -> Self {
+        Self { display }
     }
 }
 
@@ -104,32 +106,48 @@ impl<'a> Widget for BoardWidget<'a> {
             // Cell content
             for col in 0..BOARD_COLS as u16 {
                 let x_start = x_offset + col * (CELL_WIDTH + 1) + 1;
-                let content = &self.board_state.grid.0[row as usize][col as usize];
+                let display_cell = &self.display.cells[row as usize][col as usize];
 
-                match content {
-                    CellContent::Char(c) => {
-                        // " c " — character centered in 3 cells
-                        let chars = [' ', *c, ' '];
-                        for (dx, ch) in chars.iter().enumerate() {
-                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx as u16, y))
-                            {
-                                cell.set_char(*ch);
+                match display_cell {
+                    CellDisplayState::Normal(content) => match content {
+                        CellContent::Char(c) => {
+                            // " c " — character centered in 3 cells
+                            let chars = [' ', *c, ' '];
+                            for (dx, ch) in chars.iter().enumerate() {
+                                if let Some(cell) =
+                                    buf.cell_mut(Position::new(x_start + dx as u16, y))
+                                {
+                                    cell.set_char(*ch);
+                                }
                             }
                         }
-                    }
-                    CellContent::Color(color) => {
-                        let style = Style::default().bg(map_color(color));
-                        for dx in 0..CELL_WIDTH {
-                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
-                                cell.set_char(' ').set_style(style);
+                        CellContent::Color(color) => {
+                            let style = Style::default().bg(map_color(color));
+                            for dx in 0..CELL_WIDTH {
+                                if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
+                                    cell.set_char(' ').set_style(style);
+                                }
                             }
                         }
-                    }
-                    CellContent::Blank => {
-                        for dx in 0..CELL_WIDTH {
-                            if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
-                                cell.set_char(' ');
+                        CellContent::Blank => {
+                            for dx in 0..CELL_WIDTH {
+                                if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
+                                    cell.set_char(' ');
+                                }
                             }
+                        }
+                    },
+                    CellDisplayState::Flipping(ch) => {
+                        // "─X─" with dim style on the flap dashes
+                        let dim = Style::default().add_modifier(Modifier::DIM);
+                        if let Some(cell) = buf.cell_mut(Position::new(x_start, y)) {
+                            cell.set_char('─').set_style(dim);
+                        }
+                        if let Some(cell) = buf.cell_mut(Position::new(x_start + 1, y)) {
+                            cell.set_char(*ch);
+                        }
+                        if let Some(cell) = buf.cell_mut(Position::new(x_start + 2, y)) {
+                            cell.set_char('─').set_style(dim);
                         }
                     }
                 }
@@ -141,17 +159,18 @@ impl<'a> Widget for BoardWidget<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use herald_common::BoardState;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
-    fn blank_board() -> BoardState {
-        BoardState::default()
+    fn blank_display() -> DisplayGrid {
+        DisplayGrid::from_board_state(&BoardState::default())
     }
 
     #[test]
     fn too_small_shows_warning() {
-        let state = blank_board();
-        let widget = BoardWidget::new(&state);
+        let dg = blank_display();
+        let widget = BoardWidget::new(&dg);
         let area = Rect::new(0, 0, 40, 5);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -170,27 +189,23 @@ mod tests {
 
     #[test]
     fn renders_corners() {
-        let state = blank_board();
-        let widget = BoardWidget::new(&state);
+        let dg = blank_display();
+        let widget = BoardWidget::new(&dg);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
 
-        // Top-left corner
         assert_eq!(buf.cell(Position::new(0, 0)).unwrap().symbol(), "┌");
-        // Top-right corner
         assert_eq!(
             buf.cell(Position::new(GRID_WIDTH - 1, 0)).unwrap().symbol(),
             "┐"
         );
-        // Bottom-left corner
         assert_eq!(
             buf.cell(Position::new(0, GRID_HEIGHT - 1))
                 .unwrap()
                 .symbol(),
             "└"
         );
-        // Bottom-right corner
         assert_eq!(
             buf.cell(Position::new(GRID_WIDTH - 1, GRID_HEIGHT - 1))
                 .unwrap()
@@ -201,9 +216,9 @@ mod tests {
 
     #[test]
     fn renders_char_cell() {
-        let mut state = blank_board();
-        state.grid.0[0][0] = CellContent::Char('H');
-        let widget = BoardWidget::new(&state);
+        let mut dg = blank_display();
+        dg.cells[0][0] = CellDisplayState::Normal(CellContent::Char('H'));
+        let widget = BoardWidget::new(&dg);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -216,14 +231,41 @@ mod tests {
 
     #[test]
     fn renders_color_cell_background() {
-        let mut state = blank_board();
-        state.grid.0[0][0] = CellContent::Color(Color::Red);
-        let widget = BoardWidget::new(&state);
+        let mut dg = blank_display();
+        dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::Red));
+        let widget = BoardWidget::new(&dg);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
 
         let cell = buf.cell(Position::new(1, 1)).unwrap();
         assert_eq!(cell.bg, RatatuiColor::Red);
+    }
+
+    #[test]
+    fn renders_flipping_cell() {
+        let mut dg = blank_display();
+        dg.cells[0][0] = CellDisplayState::Flipping('A');
+        let widget = BoardWidget::new(&dg);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        // Cell (0,0) content starts at x=1, y=1 → should be "─A─"
+        assert_eq!(buf.cell(Position::new(1, 1)).unwrap().symbol(), "─");
+        assert_eq!(buf.cell(Position::new(2, 1)).unwrap().symbol(), "A");
+        assert_eq!(buf.cell(Position::new(3, 1)).unwrap().symbol(), "─");
+
+        // The ─ characters should have DIM modifier
+        let left = buf.cell(Position::new(1, 1)).unwrap();
+        assert!(
+            left.modifier.contains(Modifier::DIM),
+            "left dash should be DIM"
+        );
+        let right = buf.cell(Position::new(3, 1)).unwrap();
+        assert!(
+            right.modifier.contains(Modifier::DIM),
+            "right dash should be DIM"
+        );
     }
 }

--- a/crates/herald-cli/src/ui/display_state.rs
+++ b/crates/herald-cli/src/ui/display_state.rs
@@ -1,0 +1,77 @@
+use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent};
+
+/// What to display in a single cell during rendering.
+#[derive(Clone, Debug)]
+pub enum CellDisplayState {
+    /// Show normal content from the grid.
+    Normal(CellContent),
+    /// Show a character mid-flip (the intermediate cycling character, with flap visual).
+    Flipping(char),
+}
+
+/// The display state for the full board — drives what BoardWidget actually renders.
+#[derive(Clone, Debug)]
+pub struct DisplayGrid {
+    pub cells: Vec<Vec<CellDisplayState>>,
+}
+
+impl DisplayGrid {
+    /// Convert a `BoardState` into a `DisplayGrid` with all cells set to `Normal`.
+    pub fn from_board_state(state: &BoardState) -> Self {
+        let cells = state
+            .grid
+            .0
+            .iter()
+            .map(|row| row.iter().map(|c| CellDisplayState::Normal(*c)).collect())
+            .collect();
+        Self { cells }
+    }
+
+    /// Create a blank display grid (all `Normal(Blank)` cells).
+    #[allow(dead_code)] // Public API used by tests across modules
+    pub fn blank() -> Self {
+        Self {
+            cells: vec![vec![CellDisplayState::Normal(CellContent::Blank); BOARD_COLS]; BOARD_ROWS],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_board_state_produces_all_normal() {
+        let mut state = BoardState::default();
+        state.grid.0[0][0] = CellContent::Char('Z');
+        state.grid.0[1][2] = CellContent::Color(herald_common::Color::Red);
+
+        let dg = DisplayGrid::from_board_state(&state);
+        assert_eq!(dg.cells.len(), BOARD_ROWS);
+        for row in &dg.cells {
+            assert_eq!(row.len(), BOARD_COLS);
+        }
+
+        // Every cell should be Normal
+        for (r, row) in dg.cells.iter().enumerate() {
+            for (c, cell) in row.iter().enumerate() {
+                match cell {
+                    CellDisplayState::Normal(_) => {} // ok
+                    CellDisplayState::Flipping(_) => {
+                        panic!("Expected Normal at ({r},{c}), got Flipping");
+                    }
+                }
+            }
+        }
+
+        // Spot-check preserved content
+        match &dg.cells[0][0] {
+            CellDisplayState::Normal(CellContent::Char('Z')) => {}
+            other => panic!("Expected Normal(Char('Z')), got {other:?}"),
+        }
+        match &dg.cells[1][2] {
+            CellDisplayState::Normal(CellContent::Color(herald_common::Color::Red)) => {}
+            other => panic!("Expected Normal(Color(Red)), got {other:?}"),
+        }
+    }
+}

--- a/crates/herald-cli/src/ui/mod.rs
+++ b/crates/herald-cli/src/ui/mod.rs
@@ -1,5 +1,8 @@
+pub mod animation;
 mod board_widget;
+mod display_state;
 mod status_bar;
 
 pub use board_widget::BoardWidget;
+pub use display_state::DisplayGrid;
 pub use status_bar::StatusBar;


### PR DESCRIPTION
## Description

Add split-flap flip animation to the terminal board viewer (herald watch).

When the board transitions between messages, each tile now cycles through intermediate characters in the split-flap character set (A–Z, 0–9, punctuation) with a satisfying left-to-right cascade wave effect — just like a real departure board.

### What's included

- **Flip tile visual** — mid-flip tiles render as `─X─` with dimmed flap dashes, giving the appearance of a mechanical flap rotating
- **Character cycling engine** — forward-only cycling through a 57-character set (space, A–Z, 0–9, punctuation) at 50ms per step
- **Left-to-right cascade stagger** — each column starts its animation with a 20ms delay (column 0 starts immediately, column 21 at +420ms), creating the characteristic wave effect
- **Time-based animation** — uses `Instant`/`Duration` for precise timing rather than tick counting, ensuring smooth rendering regardless of frame rate
- **Mid-animation restarts** — if a new board update arrives during an animation, the new animation starts from the currently visible frame (no visual jumps)
- **Display abstraction** — new `DisplayGrid`/`CellDisplayState` layer decouples animation state from the rendering widget, keeping the widget stateless

## Related Issues

Closes #30, Closes #31, Closes #32

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)