### PR TITLE
feat: add board diff detection, resize handling, and PowerShell scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split-flap flip animation in `herald watch` — tiles cycle through intermediate characters with a "─X─" mid-flip visual when the board transitions between messages
 - Left-to-right cascade stagger effect: columns start their flip animation with a 20ms delay between each, creating the characteristic split-flap wave
 - Time-based animation engine with configurable step duration (50ms/char) and column stagger (20ms), smooth mid-animation restarts when new board updates arrive
+- Board diff detection: only changed cells animate on board transitions, identical boards skip animation entirely
+- Terminal resize handling: board re-centers on resize, in-progress animations cancel and snap to target state
+- PowerShell helper scripts (`scripts/`) for common operations: `add-message`, `remove-message`, `add-countdown`, `set-rotation-interval`

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -119,16 +119,24 @@ async fn run_tui(
                     current_display.clone()
                 };
 
-                animation = Some(BoardAnimation::new(
+                let new_anim = BoardAnimation::new(
                     &from_display,
                     &new_board,
                     STEP_DURATION,
                     STAGGER_PER_COLUMN,
-                ));
+                );
 
-                // Render immediately with the new animation's first frame
-                let now = Instant::now();
-                current_display = animation.as_ref().unwrap().sample(now);
+                if new_anim.has_changes() {
+                    animation = Some(new_anim);
+
+                    // Render immediately with the new animation's first frame
+                    let now = Instant::now();
+                    current_display = animation.as_ref().unwrap().sample(now);
+                } else {
+                    // No changes — update display directly, skip animation
+                    current_display = DisplayGrid::from_board_state(&new_board);
+                }
+
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
@@ -167,7 +175,7 @@ async fn run_tui(
                     draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
                 })?;
 
-                if event::poll(Duration::from_millis(0))? {
+                while event::poll(Duration::from_millis(0))? {
                     match event::read()? {
                         Event::Key(key) if key.kind == KeyEventKind::Press => {
                             match key.code {
@@ -179,6 +187,19 @@ async fn run_tui(
                                 }
                                 _ => {}
                             }
+                        }
+                        Event::Resize(_width, _height) => {
+                            // Cancel any in-progress animation and snap to target
+                            if let Some(ref anim) = animation {
+                                current_display = DisplayGrid::from_board_state(anim.target());
+                                animation = None;
+                            }
+                            // Re-draw immediately with the new terminal size
+                            let conn_state = conn_rx.borrow().clone();
+                            let queue_info = queue_rx.borrow().clone();
+                            terminal.draw(|frame| {
+                                draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                            })?;
                         }
                         _ => {}
                     }

--- a/crates/herald-cli/src/ui/animation.rs
+++ b/crates/herald-cli/src/ui/animation.rs
@@ -195,6 +195,16 @@ impl BoardAnimation {
         DisplayGrid { cells: grid_cells }
     }
 
+    /// Returns true if there are any animated cells (boards were not identical).
+    pub fn has_changes(&self) -> bool {
+        self.cells.iter().any(|row| row.iter().any(|c| c.is_some()))
+    }
+
+    /// Get the target board state this animation is transitioning to.
+    pub fn target(&self) -> &BoardState {
+        &self.target
+    }
+
     /// Returns `true` when all cells have finished their animation.
     pub fn is_complete(&self, now: Instant) -> bool {
         for row in &self.cells {
@@ -503,5 +513,32 @@ mod tests {
         // 'B' → 'A' forward-cycling should go: C, D, E, ..., Z, 0-9, punctuation, ' ', A
         assert_eq!(*cell_anim.steps.last().unwrap(), 'A');
         assert!(cell_anim.steps.len() > 2); // definitely wraps around
+    }
+
+    #[test]
+    fn test_has_changes_when_no_changes() {
+        let display = make_blank_display();
+        let mut target = BoardState::default();
+        target.grid = Grid::blank();
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+        assert!(!anim.has_changes());
+    }
+
+    #[test]
+    fn test_has_changes_when_changed() {
+        let display = make_blank_display();
+        let target = make_board_with_char('A');
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+        assert!(anim.has_changes());
     }
 }

--- a/crates/herald-cli/src/ui/board_widget.rs
+++ b/crates/herald-cli/src/ui/board_widget.rs
@@ -43,7 +43,7 @@ impl<'a> Widget for BoardWidget<'a> {
         // Show a warning if the terminal is too small.
         if area.width < GRID_WIDTH || area.height < GRID_HEIGHT {
             let msg = format!(
-                "Terminal too small (need {}×{}, have {}×{})",
+                "Terminal too small. Minimum: {}×{} (have {}×{})",
                 GRID_WIDTH, GRID_HEIGHT, area.width, area.height
             );
             let paragraph = Paragraph::new(Text::raw(msg)).alignment(Alignment::Center);

--- a/crates/herald-common/src/lib.rs
+++ b/crates/herald-common/src/lib.rs
@@ -174,4 +174,47 @@ mod tests {
             assert!(!row_text(&grid, r).is_empty());
         }
     }
+
+    #[test]
+    fn test_diff_grids_identical() {
+        let a = Grid::blank();
+        let b = Grid::blank();
+        let diffs = Grid::diff_grids(&a, &b);
+        assert!(diffs.is_empty());
+        assert!(Grid::grids_are_identical(&a, &b));
+    }
+
+    #[test]
+    fn test_diff_grids_one_change() {
+        let a = Grid::blank();
+        let mut b = Grid::blank();
+        b.0[2][10] = CellContent::Char('X');
+        let diffs = Grid::diff_grids(&a, &b);
+        assert_eq!(diffs, vec![(2, 10)]);
+        assert!(!Grid::grids_are_identical(&a, &b));
+    }
+
+    #[test]
+    fn test_diff_grids_multiple_changes() {
+        let a = Grid::blank();
+        let mut b = Grid::blank();
+        b.0[0][0] = CellContent::Char('A');
+        b.0[3][15] = CellContent::Char('B');
+        b.0[5][21] = CellContent::Char('C');
+        let diffs = Grid::diff_grids(&a, &b);
+        assert_eq!(diffs, vec![(0, 0), (3, 15), (5, 21)]);
+    }
+
+    #[test]
+    fn test_diff_grids_all_different() {
+        let a = Grid::blank();
+        let mut b = Grid::blank();
+        for row in &mut b.0 {
+            for cell in row.iter_mut() {
+                *cell = CellContent::Char('Z');
+            }
+        }
+        let diffs = Grid::diff_grids(&a, &b);
+        assert_eq!(diffs.len(), BOARD_ROWS * BOARD_COLS); // 6 * 22 = 132
+    }
 }

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -213,6 +213,24 @@ impl Grid {
 
         Ok(grid)
     }
+
+    /// Compare two grids and return the (row, col) positions of cells that differ.
+    pub fn diff_grids(old: &Grid, new: &Grid) -> Vec<(usize, usize)> {
+        let mut diffs = Vec::new();
+        for (row_idx, (old_row, new_row)) in old.0.iter().zip(new.0.iter()).enumerate() {
+            for (col_idx, (old_cell, new_cell)) in old_row.iter().zip(new_row.iter()).enumerate() {
+                if old_cell != new_cell {
+                    diffs.push((row_idx, col_idx));
+                }
+            }
+        }
+        diffs
+    }
+
+    /// Returns true if the two grids are identical (no cells differ).
+    pub fn grids_are_identical(old: &Grid, new: &Grid) -> bool {
+        Grid::diff_grids(old, new).is_empty()
+    }
 }
 
 impl Default for Grid {

--- a/scripts/add-countdown.ps1
+++ b/scripts/add-countdown.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    Add a countdown timer to the Herald board rotation.
+.EXAMPLE
+    .\add-countdown.ps1 -Token "mytoken" -Label "LAUNCH" -Target "2026-12-31T00:00:00Z"
+    .\add-countdown.ps1 -Token "mytoken" -Label "MEETING" -InMinutes 45
+    .\add-countdown.ps1 -Token "mytoken" -Label "DEADLINE" -InHours 8
+#>
+param(
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)][string]$Label,
+    [string]$Target,       # ISO 8601 datetime
+    [int]$InMinutes,       # countdown N minutes from now
+    [int]$InHours,         # countdown N hours from now
+    [string]$Server = "http://localhost:3000",
+    [ValidateSet("show_zero","remove","pause")][string]$ZeroBehavior = "show_zero"
+)
+
+if (-not $Target -and -not $InMinutes -and -not $InHours) {
+    Write-Error "Provide -Target (ISO datetime), -InMinutes, or -InHours"
+    return
+}
+
+if ($InMinutes) {
+    $Target = (Get-Date).AddMinutes($InMinutes).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+} elseif ($InHours) {
+    $Target = (Get-Date).AddHours($InHours).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+}
+
+$body = @{
+    label = $Label
+    target = $Target
+    zero_behavior = @{ action = $ZeroBehavior }
+}
+
+$result = Invoke-RestMethod -Uri "$Server/api/countdowns" -Method Post `
+    -Headers @{ Authorization = "Bearer $Token" } `
+    -ContentType "application/json" `
+    -Body ($body | ConvertTo-Json -Depth 3)
+
+Write-Host "Countdown added (id: $($result.id), target: $Target)"
+$result

--- a/scripts/add-message.ps1
+++ b/scripts/add-message.ps1
@@ -1,0 +1,29 @@
+<#
+.SYNOPSIS
+    Add a text message to the Herald board rotation.
+.EXAMPLE
+    .\add-message.ps1 -Token "mytoken" -Text "HELLO WORLD"
+    .\add-message.ps1 -Token "mytoken" -Text "LEFT ALIGNED" -HAlign left
+    .\add-message.ps1 -Token "mytoken" -Text "EXPIRES SOON" -ExpiresIn 300
+#>
+param(
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)][string]$Text,
+    [string]$Server = "http://localhost:3000",
+    [ValidateSet("left","center","right")][string]$HAlign = "center",
+    [ValidateSet("top","middle")][string]$VAlign = "middle",
+    [int]$ExpiresIn  # seconds from now
+)
+
+$body = @{ text = $Text; h_align = $HAlign; v_align = $VAlign }
+if ($ExpiresIn) {
+    $body.expires_at = (Get-Date).AddSeconds($ExpiresIn).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+}
+
+$result = Invoke-RestMethod -Uri "$Server/api/messages" -Method Post `
+    -Headers @{ Authorization = "Bearer $Token" } `
+    -ContentType "application/json" `
+    -Body ($body | ConvertTo-Json -Depth 3)
+
+Write-Host "Message added (id: $($result.id))"
+$result

--- a/scripts/remove-message.ps1
+++ b/scripts/remove-message.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Remove a message from the Herald board rotation.
+.EXAMPLE
+    .\remove-message.ps1 -Token "mytoken" -Id "some-uuid"
+    .\remove-message.ps1 -Token "mytoken" -All   # remove all messages
+#>
+param(
+    [Parameter(Mandatory)][string]$Token,
+    [string]$Id,
+    [switch]$All,
+    [string]$Server = "http://localhost:3000"
+)
+
+if (-not $Id -and -not $All) {
+    # List messages so the user can pick one
+    $list = Invoke-RestMethod -Uri "$Server/api/messages" -Method Get `
+        -Headers @{ Authorization = "Bearer $Token" }
+    if ($list.total -eq 0) {
+        Write-Host "No messages in rotation."
+        return
+    }
+    Write-Host "Messages in rotation:"
+    foreach ($m in $list.items) {
+        $preview = if ($m.source_text) { $m.source_text } else { "(raw grid)" }
+        Write-Host "  $($m.id)  $preview"
+    }
+    Write-Host "`nUse -Id <uuid> to remove a specific message, or -All to remove all."
+    return
+}
+
+if ($All) {
+    $list = Invoke-RestMethod -Uri "$Server/api/messages" -Method Get `
+        -Headers @{ Authorization = "Bearer $Token" }
+    foreach ($m in $list.items) {
+        Invoke-RestMethod -Uri "$Server/api/messages/$($m.id)" -Method Delete `
+            -Headers @{ Authorization = "Bearer $Token" } | Out-Null
+        Write-Host "Deleted $($m.id)"
+    }
+    Write-Host "All $($list.total) message(s) removed."
+} else {
+    Invoke-RestMethod -Uri "$Server/api/messages/$Id" -Method Delete `
+        -Headers @{ Authorization = "Bearer $Token" }
+    Write-Host "Message $Id removed."
+}

--- a/scripts/set-rotation-interval.ps1
+++ b/scripts/set-rotation-interval.ps1
@@ -1,0 +1,27 @@
+<#
+.SYNOPSIS
+    Update the rotation interval (seconds between board transitions).
+.EXAMPLE
+    .\set-rotation-interval.ps1 -Token "mytoken" -Seconds 15
+    .\set-rotation-interval.ps1 -Token "mytoken" -Seconds 60
+#>
+param(
+    [Parameter(Mandatory)][string]$Token,
+    [Parameter(Mandatory)][int]$Seconds,
+    [string]$Server = "http://localhost:3000"
+)
+
+if ($Seconds -lt 1) {
+    Write-Error "Interval must be at least 1 second."
+    return
+}
+
+$body = @{ rotation_interval_seconds = $Seconds.ToString() }
+
+$result = Invoke-RestMethod -Uri "$Server/api/config" -Method Put `
+    -Headers @{ Authorization = "Bearer $Token" } `
+    -ContentType "application/json" `
+    -Body ($body | ConvertTo-Json)
+
+Write-Host "Rotation interval set to ${Seconds}s"
+$result


### PR DESCRIPTION
## Description

Add board diff detection, terminal resize handling, and PowerShell helper scripts.

### What's included

- **Board diff detection (#34)** — `Grid::diff_grids()` compares old and new grids cell-by-cell, and `BoardAnimation::has_changes()` lets the watch command skip animation entirely when boards are identical. This reduces visual noise and CPU usage on redundant updates.
- **Terminal resize handling (#35)** — the `herald watch` event loop now handles `Event::Resize`, cancelling any in-progress animation and snapping to the target state so the board re-centers immediately in the new viewport. The "too small" warning message was updated to `Terminal too small. Minimum: 89×13 (have WxH)`. Event polling changed from `if` to `while` to drain all queued events per tick.
- **PowerShell helper scripts** — four scripts in `scripts/` for quick administration:
  - `add-message.ps1` — push a text message (supports alignment, expiry)
  - `remove-message.ps1` — remove by ID, remove all, or list messages
  - `add-countdown.ps1` — create a countdown by target datetime or relative minutes/hours
  - `set-rotation-interval.ps1` — change the rotation interval in seconds

## Related Issues

Closes #34, Closes #35

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)