### PR TITLE
feat: add ANSI 256-color support, animation speed flag, and rendering optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Board diff detection: only changed cells animate on board transitions, identical boards skip animation entirely
 - Terminal resize handling: board re-centers on resize, in-progress animations cancel and snap to target state
 - PowerShell helper scripts (`scripts/`) for common operations: `add-message`, `remove-message`, `add-countdown`, `set-rotation-interval`
+- ANSI 256-color support for color tiles with automatic fallback to basic 8-color mode on older terminals
+- `--animation-speed` flag on `herald watch`: `fast`, `normal` (default), `slow`, or `off` to control flip animation timing
+- `list-queue.ps1` script to display all messages and countdowns currently in the rotation queue
+- All PowerShell scripts auto-detect `$env:HERALD_ADMIN_TOKEN`, removing the need to pass `-Token` every time
+
+### Changed
+
+- Optimized animation rendering: pre-allocated display buffers and frame-skip logic for smooth 30fps playback

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -12,16 +12,47 @@ use crate::ui::animation::BoardAnimation;
 use crate::ui::{BoardWidget, DisplayGrid, StatusBar};
 use crate::ws_client::WsClient;
 
-/// Default duration for each character step in the cycling animation.
-const STEP_DURATION: Duration = Duration::from_millis(50);
-
-/// Default cascade delay between columns.
-const STAGGER_PER_COLUMN: Duration = Duration::from_millis(20);
-
 /// Minimum tick interval during animation for smooth rendering.
 const ANIMATION_TICK: Duration = Duration::from_millis(20);
 
-pub async fn run(server: String, fps: u16) -> Result<(), Box<dyn std::error::Error>> {
+/// Animation speed presets for split-flap flip animation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum AnimationSpeed {
+    /// Fast: 25ms/step, 10ms stagger
+    Fast,
+    /// Normal: 50ms/step, 20ms stagger (default)
+    Normal,
+    /// Slow: 100ms/step, 40ms stagger
+    Slow,
+    /// Off: instant transitions, no animation
+    Off,
+}
+
+impl AnimationSpeed {
+    pub fn step_duration(&self) -> Duration {
+        match self {
+            Self::Fast => Duration::from_millis(25),
+            Self::Normal => Duration::from_millis(50),
+            Self::Slow => Duration::from_millis(100),
+            Self::Off => Duration::ZERO,
+        }
+    }
+
+    pub fn stagger_per_column(&self) -> Duration {
+        match self {
+            Self::Fast => Duration::from_millis(10),
+            Self::Normal => Duration::from_millis(20),
+            Self::Slow => Duration::from_millis(40),
+            Self::Off => Duration::ZERO,
+        }
+    }
+}
+
+pub async fn run(
+    server: String,
+    fps: u16,
+    speed: AnimationSpeed,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (client, mut board_rx, mut conn_rx, mut queue_rx) = WsClient::new(server.clone());
 
     tokio::spawn(async move {
@@ -40,6 +71,7 @@ pub async fn run(server: String, fps: u16) -> Result<(), Box<dyn std::error::Err
         &mut queue_rx,
         &server,
         fps,
+        speed,
     )
     .await;
 
@@ -58,13 +90,17 @@ async fn run_tui(
     queue_rx: &mut tokio::sync::watch::Receiver<crate::ws_client::QueueInfoState>,
     server_url: &str,
     fps: u16,
+    speed: AnimationSpeed,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let normal_tick = Duration::from_millis(1000 / fps.max(1) as u64);
     let mut last_update: Option<Instant> = None;
 
-    // Animation state
+    // Animation state — pre-allocate the display buffer once and reuse it
     let mut current_display = DisplayGrid::from_board_state(&board_rx.borrow());
     let mut animation: Option<BoardAnimation> = None;
+
+    // Frame skip: track when we last rendered to avoid catching up
+    let mut last_frame_time = Instant::now();
 
     let draw = |frame: &mut ratatui::Frame,
                 display: &DisplayGrid,
@@ -112,30 +148,37 @@ async fn run_tui(
                 last_update = Some(Instant::now());
                 let new_board = board_rx.borrow().clone();
 
-                // Start animation from the currently visible display state
-                let from_display = if let Some(ref anim) = animation {
-                    anim.sample(Instant::now())
+                if speed == AnimationSpeed::Off {
+                    // Instant transition — skip animation entirely
+                    animation = None;
+                    current_display.fill_from_board_state(&new_board);
                 } else {
-                    current_display.clone()
-                };
+                    // Start animation from the currently visible display state
+                    if let Some(ref anim) = animation {
+                        // Reuse current_display buffer for the mid-animation snapshot
+                        anim.sample_into(Instant::now(), &mut current_display);
+                    }
 
-                let new_anim = BoardAnimation::new(
-                    &from_display,
-                    &new_board,
-                    STEP_DURATION,
-                    STAGGER_PER_COLUMN,
-                );
+                    let new_anim = BoardAnimation::new(
+                        &current_display,
+                        &new_board,
+                        speed.step_duration(),
+                        speed.stagger_per_column(),
+                    );
 
-                if new_anim.has_changes() {
-                    animation = Some(new_anim);
+                    if new_anim.has_changes() {
+                        animation = Some(new_anim);
 
-                    // Render immediately with the new animation's first frame
-                    let now = Instant::now();
-                    current_display = animation.as_ref().unwrap().sample(now);
-                } else {
-                    // No changes — update display directly, skip animation
-                    current_display = DisplayGrid::from_board_state(&new_board);
+                        // Render immediately with the new animation's first frame
+                        let now = Instant::now();
+                        animation.as_ref().unwrap().sample_into(now, &mut current_display);
+                    } else {
+                        // No changes — update display directly, skip animation
+                        current_display.fill_from_board_state(&new_board);
+                    }
                 }
+
+                last_frame_time = Instant::now();
 
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
@@ -161,7 +204,14 @@ async fn run_tui(
                 // Advance animation if active
                 if let Some(ref anim) = animation {
                     let now = Instant::now();
-                    current_display = anim.sample(now);
+                    let elapsed_since_last_frame = now.duration_since(last_frame_time);
+
+                    if elapsed_since_last_frame >= tick_duration {
+                        // Frame skip: if more than 3 ticks behind we still just
+                        // sample the latest state (no intermediate catch-up).
+                        anim.sample_into(now, &mut current_display);
+                        last_frame_time = now;
+                    }
 
                     if anim.is_complete(now) {
                         // Animation finished — settle on the final target state
@@ -191,7 +241,7 @@ async fn run_tui(
                         Event::Resize(_width, _height) => {
                             // Cancel any in-progress animation and snap to target
                             if let Some(ref anim) = animation {
-                                current_display = DisplayGrid::from_board_state(anim.target());
+                                current_display.fill_from_board_state(anim.target());
                                 animation = None;
                             }
                             // Re-draw immediately with the new terminal size

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -3,6 +3,7 @@ mod ui;
 mod ws_client;
 
 use clap::{Parser, Subcommand};
+use commands::watch::AnimationSpeed;
 
 #[derive(Parser)]
 #[command(name = "herald")]
@@ -24,6 +25,9 @@ enum Command {
         /// Target frames per second for the UI refresh rate
         #[arg(long, default_value_t = 30)]
         fps: u16,
+        /// Animation speed: fast, normal, slow, or off
+        #[arg(long, default_value = "normal")]
+        animation_speed: AnimationSpeed,
     },
     /// Push a message to the board
     Push,
@@ -40,7 +44,11 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Watch { server, fps } => commands::watch::run(server, fps).await,
+        Command::Watch {
+            server,
+            fps,
+            animation_speed,
+        } => commands::watch::run(server, fps, animation_speed).await,
         Command::Serve => {
             eprintln!("serve is not yet implemented");
             Ok(())

--- a/crates/herald-cli/src/ui/animation.rs
+++ b/crates/herald-cli/src/ui/animation.rs
@@ -37,7 +37,7 @@ pub fn cycling_steps(from: char, to: char) -> Vec<char> {
     };
 
     let len = CHAR_SET.len();
-    let mut steps = Vec::new();
+    let mut steps = Vec::with_capacity(CHAR_SET.len());
     let mut i = (from_idx + 1) % len;
     loop {
         steps.push(CHAR_SET[i]);
@@ -150,6 +150,7 @@ impl BoardAnimation {
     }
 
     /// Sample the animation at a given instant, producing the current `DisplayGrid`.
+    #[allow(dead_code)] // Kept for backward compatibility; tests use this method
     pub fn sample(&self, now: Instant) -> DisplayGrid {
         let mut grid_cells = Vec::with_capacity(BOARD_ROWS);
 
@@ -203,6 +204,37 @@ impl BoardAnimation {
     /// Get the target board state this animation is transitioning to.
     pub fn target(&self) -> &BoardState {
         &self.target
+    }
+
+    /// Sample the animation at a given instant, writing into an existing `DisplayGrid`
+    /// to avoid per-frame allocation.
+    pub fn sample_into(&self, now: Instant, display: &mut DisplayGrid) {
+        for row in 0..BOARD_ROWS {
+            for col in 0..BOARD_COLS {
+                let state = match &self.cells[row][col] {
+                    None => CellDisplayState::Normal(self.target.grid.0[row][col]),
+                    Some(anim) => {
+                        let effective_start = anim.created_at + anim.delay;
+                        if now < effective_start {
+                            cell_display_for_char(anim.from_char)
+                        } else if anim.steps.is_empty() {
+                            CellDisplayState::Normal(anim.target)
+                        } else {
+                            let elapsed = now.duration_since(effective_start);
+                            let step_idx =
+                                (elapsed.as_nanos() / self.step_duration.as_nanos()) as usize;
+
+                            if step_idx >= anim.steps.len() - 1 {
+                                CellDisplayState::Normal(anim.target)
+                            } else {
+                                CellDisplayState::Flipping(anim.steps[step_idx])
+                            }
+                        }
+                    }
+                };
+                display.set(row, col, state);
+            }
+        }
     }
 
     /// Returns `true` when all cells have finished their animation.
@@ -540,5 +572,51 @@ mod tests {
             Duration::from_millis(20),
         );
         assert!(anim.has_changes());
+    }
+
+    #[test]
+    fn test_sample_into_matches_sample() {
+        let display = make_blank_display();
+        let target = make_board_with_char('D');
+        let anim = BoardAnimation::new(
+            &display,
+            &target,
+            Duration::from_millis(50),
+            Duration::from_millis(20),
+        );
+
+        // Sample at several time points and verify sample_into gives the same result
+        for offset_ms in [0, 25, 75, 150, 500] {
+            let t = anim.created_at + Duration::from_millis(offset_ms);
+            let from_sample = anim.sample(t);
+            let mut into_buf = make_blank_display();
+            anim.sample_into(t, &mut into_buf);
+
+            for r in 0..BOARD_ROWS {
+                for c in 0..BOARD_COLS {
+                    assert_eq!(
+                        format!("{:?}", from_sample.cells[r][c]),
+                        format!("{:?}", into_buf.cells[r][c]),
+                        "mismatch at ({r},{c}) t={offset_ms}ms"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_fill_from_board_state_reuses_allocation() {
+        let mut display = make_blank_display();
+        let ptr_before = display.cells.as_ptr();
+
+        let target = make_board_with_char('Z');
+        display.fill_from_board_state(&target);
+
+        // Vec should not have reallocated
+        assert_eq!(display.cells.as_ptr(), ptr_before);
+        match &display.cells[0][0] {
+            CellDisplayState::Normal(CellContent::Char('Z')) => {}
+            other => panic!("Expected Normal(Char('Z')), got {other:?}"),
+        }
     }
 }

--- a/crates/herald-cli/src/ui/board_widget.rs
+++ b/crates/herald-cli/src/ui/board_widget.rs
@@ -13,8 +13,22 @@ const CELL_WIDTH: u16 = 3;
 const GRID_WIDTH: u16 = BOARD_COLS as u16 * CELL_WIDTH + BOARD_COLS as u16 + 1; // 89
 const GRID_HEIGHT: u16 = BOARD_ROWS as u16 + BOARD_ROWS as u16 + 1; // 13
 
-/// Maps a Herald color to a ratatui terminal color.
-fn map_color(color: &Color) -> RatatuiColor {
+/// Maps a Herald color to an ANSI 256-color indexed value.
+fn map_color_256(color: &Color) -> RatatuiColor {
+    match color {
+        Color::Red => RatatuiColor::Indexed(196),
+        Color::Orange => RatatuiColor::Indexed(208),
+        Color::Yellow => RatatuiColor::Indexed(226),
+        Color::Green => RatatuiColor::Indexed(46),
+        Color::Blue => RatatuiColor::Indexed(21),
+        Color::Violet => RatatuiColor::Indexed(93),
+        Color::White => RatatuiColor::Indexed(231),
+        Color::Black => RatatuiColor::Indexed(232),
+    }
+}
+
+/// Basic 8-color fallback for terminals without 256-color support.
+fn map_color_basic(color: &Color) -> RatatuiColor {
     match color {
         Color::Red => RatatuiColor::Red,
         Color::Orange => RatatuiColor::Rgb(255, 165, 0),
@@ -25,6 +39,29 @@ fn map_color(color: &Color) -> RatatuiColor {
         Color::White => RatatuiColor::White,
         Color::Black => RatatuiColor::Black,
     }
+}
+
+/// Maps a Herald color to a terminal color, with fallback for basic terminals.
+fn map_color_with_fallback(color: &Color, use_256: bool) -> RatatuiColor {
+    if use_256 {
+        map_color_256(color)
+    } else {
+        map_color_basic(color)
+    }
+}
+
+/// Detects whether the terminal supports 256 colors via environment variables.
+fn supports_256_colors() -> bool {
+    if let Ok(colorterm) = std::env::var("COLORTERM")
+        && (colorterm == "truecolor" || colorterm == "24bit")
+    {
+        return true;
+    }
+    if let Ok(term) = std::env::var("TERM") {
+        return term.contains("256color") || term.contains("xterm") || term.contains("screen");
+    }
+    // Default to 256 on modern systems
+    true
 }
 
 /// A ratatui widget that renders the Herald 6×22 board grid with box-drawing borders.
@@ -122,7 +159,17 @@ impl<'a> Widget for BoardWidget<'a> {
                             }
                         }
                         CellContent::Color(color) => {
-                            let style = Style::default().bg(map_color(color));
+                            let use_256 = supports_256_colors();
+                            let bg = map_color_with_fallback(color, use_256);
+                            let style = match color {
+                                Color::White => {
+                                    Style::default().bg(bg).fg(RatatuiColor::Indexed(232))
+                                }
+                                Color::Black => {
+                                    Style::default().bg(bg).fg(RatatuiColor::Indexed(231))
+                                }
+                                _ => Style::default().bg(bg),
+                            };
                             for dx in 0..CELL_WIDTH {
                                 if let Some(cell) = buf.cell_mut(Position::new(x_start + dx, y)) {
                                     cell.set_char(' ').set_style(style);
@@ -239,7 +286,36 @@ mod tests {
         widget.render(area, &mut buf);
 
         let cell = buf.cell(Position::new(1, 1)).unwrap();
-        assert_eq!(cell.bg, RatatuiColor::Red);
+        // With 256-color support (default), Red maps to Indexed(196)
+        assert_eq!(cell.bg, RatatuiColor::Indexed(196));
+    }
+
+    #[test]
+    fn renders_white_color_cell_with_dark_foreground() {
+        let mut dg = blank_display();
+        dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::White));
+        let widget = BoardWidget::new(&dg);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let cell = buf.cell(Position::new(1, 1)).unwrap();
+        assert_eq!(cell.bg, RatatuiColor::Indexed(231));
+        assert_eq!(cell.fg, RatatuiColor::Indexed(232));
+    }
+
+    #[test]
+    fn renders_black_color_cell_with_white_foreground() {
+        let mut dg = blank_display();
+        dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::Black));
+        let widget = BoardWidget::new(&dg);
+        let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
+        let mut buf = Buffer::empty(area);
+        widget.render(area, &mut buf);
+
+        let cell = buf.cell(Position::new(1, 1)).unwrap();
+        assert_eq!(cell.bg, RatatuiColor::Indexed(232));
+        assert_eq!(cell.fg, RatatuiColor::Indexed(231));
     }
 
     #[test]

--- a/crates/herald-cli/src/ui/display_state.rs
+++ b/crates/herald-cli/src/ui/display_state.rs
@@ -34,6 +34,20 @@ impl DisplayGrid {
             cells: vec![vec![CellDisplayState::Normal(CellContent::Blank); BOARD_COLS]; BOARD_ROWS],
         }
     }
+
+    /// Set a cell in the display grid.
+    pub fn set(&mut self, row: usize, col: usize, state: CellDisplayState) {
+        self.cells[row][col] = state;
+    }
+
+    /// Overwrite every cell from a `BoardState`, reusing the existing allocation.
+    pub fn fill_from_board_state(&mut self, state: &BoardState) {
+        for (r, row) in state.grid.0.iter().enumerate() {
+            for (c, cell) in row.iter().enumerate() {
+                self.cells[r][c] = CellDisplayState::Normal(*cell);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/scripts/add-countdown.ps1
+++ b/scripts/add-countdown.ps1
@@ -2,12 +2,14 @@
 .SYNOPSIS
     Add a countdown timer to the Herald board rotation.
 .EXAMPLE
-    .\add-countdown.ps1 -Token "mytoken" -Label "LAUNCH" -Target "2026-12-31T00:00:00Z"
-    .\add-countdown.ps1 -Token "mytoken" -Label "MEETING" -InMinutes 45
-    .\add-countdown.ps1 -Token "mytoken" -Label "DEADLINE" -InHours 8
+    .\add-countdown.ps1 -Label "LAUNCH" -Target "2026-12-31T00:00:00Z"
+    .\add-countdown.ps1 -Label "MEETING" -InMinutes 45
+    .\add-countdown.ps1 -Label "DEADLINE" -InHours 8
+.NOTES
+    Uses $env:HERALD_ADMIN_TOKEN if -Token is not provided.
 #>
 param(
-    [Parameter(Mandatory)][string]$Token,
+    [string]$Token,
     [Parameter(Mandatory)][string]$Label,
     [string]$Target,       # ISO 8601 datetime
     [int]$InMinutes,       # countdown N minutes from now
@@ -15,6 +17,9 @@ param(
     [string]$Server = "http://localhost:3000",
     [ValidateSet("show_zero","remove","pause")][string]$ZeroBehavior = "show_zero"
 )
+
+if (-not $Token) { $Token = $env:HERALD_ADMIN_TOKEN }
+if (-not $Token) { Write-Error "Provide -Token or set `$env:HERALD_ADMIN_TOKEN"; return }
 
 if (-not $Target -and -not $InMinutes -and -not $InHours) {
     Write-Error "Provide -Target (ISO datetime), -InMinutes, or -InHours"

--- a/scripts/add-message.ps1
+++ b/scripts/add-message.ps1
@@ -2,18 +2,23 @@
 .SYNOPSIS
     Add a text message to the Herald board rotation.
 .EXAMPLE
-    .\add-message.ps1 -Token "mytoken" -Text "HELLO WORLD"
-    .\add-message.ps1 -Token "mytoken" -Text "LEFT ALIGNED" -HAlign left
+    .\add-message.ps1 -Text "HELLO WORLD"
+    .\add-message.ps1 -Text "LEFT ALIGNED" -HAlign left
     .\add-message.ps1 -Token "mytoken" -Text "EXPIRES SOON" -ExpiresIn 300
+.NOTES
+    Uses $env:HERALD_ADMIN_TOKEN if -Token is not provided.
 #>
 param(
-    [Parameter(Mandatory)][string]$Token,
+    [string]$Token,
     [Parameter(Mandatory)][string]$Text,
     [string]$Server = "http://localhost:3000",
     [ValidateSet("left","center","right")][string]$HAlign = "center",
     [ValidateSet("top","middle")][string]$VAlign = "middle",
     [int]$ExpiresIn  # seconds from now
 )
+
+if (-not $Token) { $Token = $env:HERALD_ADMIN_TOKEN }
+if (-not $Token) { Write-Error "Provide -Token or set `$env:HERALD_ADMIN_TOKEN"; return }
 
 $body = @{ text = $Text; h_align = $HAlign; v_align = $VAlign }
 if ($ExpiresIn) {

--- a/scripts/list-queue.ps1
+++ b/scripts/list-queue.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    List all messages and countdowns currently in the Herald rotation queue.
+.EXAMPLE
+    .\list-queue.ps1
+    .\list-queue.ps1 -Server "http://myhost:3000"
+.NOTES
+    Uses $env:HERALD_ADMIN_TOKEN if -Token is not provided.
+#>
+param(
+    [string]$Token,
+    [string]$Server = "http://localhost:3000"
+)
+
+if (-not $Token) { $Token = $env:HERALD_ADMIN_TOKEN }
+if (-not $Token) { Write-Error "Provide -Token or set `$env:HERALD_ADMIN_TOKEN"; return }
+
+$headers = @{ Authorization = "Bearer $Token" }
+
+$queue = Invoke-RestMethod -Uri "$Server/api/queue" -Method Get -Headers $headers
+
+if ($queue.total -eq 0) {
+    Write-Host "Queue is empty — the HERALD splash screen is showing."
+    return
+}
+
+Write-Host "Queue ($($queue.total) items):`n"
+
+$i = 1
+foreach ($item in $queue.items) {
+    $kind = $item.kind
+    $label = $item.label
+    $id = $item.id
+    $expires = if ($item.expires_at) { " (expires $($item.expires_at))" } else { "" }
+
+    if ($kind -eq "message") {
+        Write-Host ("  {0,2}. [MSG]       {1}{2}" -f $i, $label, $expires)
+    } elseif ($kind -eq "countdown") {
+        Write-Host ("  {0,2}. [COUNTDOWN] {1}{2}" -f $i, $label, $expires)
+    } else {
+        Write-Host ("  {0,2}. [{1}] {2}{3}" -f $i, $kind.ToUpper(), $label, $expires)
+    }
+    Write-Host "      id: $id"
+    $i++
+}

--- a/scripts/remove-message.ps1
+++ b/scripts/remove-message.ps1
@@ -2,15 +2,21 @@
 .SYNOPSIS
     Remove a message from the Herald board rotation.
 .EXAMPLE
-    .\remove-message.ps1 -Token "mytoken" -Id "some-uuid"
-    .\remove-message.ps1 -Token "mytoken" -All   # remove all messages
+    .\remove-message.ps1 -Id "some-uuid"
+    .\remove-message.ps1 -All
+    .\remove-message.ps1          # lists messages to choose from
+.NOTES
+    Uses $env:HERALD_ADMIN_TOKEN if -Token is not provided.
 #>
 param(
-    [Parameter(Mandatory)][string]$Token,
+    [string]$Token,
     [string]$Id,
     [switch]$All,
     [string]$Server = "http://localhost:3000"
 )
+
+if (-not $Token) { $Token = $env:HERALD_ADMIN_TOKEN }
+if (-not $Token) { Write-Error "Provide -Token or set `$env:HERALD_ADMIN_TOKEN"; return }
 
 if (-not $Id -and -not $All) {
     # List messages so the user can pick one

--- a/scripts/set-rotation-interval.ps1
+++ b/scripts/set-rotation-interval.ps1
@@ -2,14 +2,19 @@
 .SYNOPSIS
     Update the rotation interval (seconds between board transitions).
 .EXAMPLE
-    .\set-rotation-interval.ps1 -Token "mytoken" -Seconds 15
-    .\set-rotation-interval.ps1 -Token "mytoken" -Seconds 60
+    .\set-rotation-interval.ps1 -Seconds 15
+    .\set-rotation-interval.ps1 -Seconds 60
+.NOTES
+    Uses $env:HERALD_ADMIN_TOKEN if -Token is not provided.
 #>
 param(
-    [Parameter(Mandatory)][string]$Token,
+    [string]$Token,
     [Parameter(Mandatory)][int]$Seconds,
     [string]$Server = "http://localhost:3000"
 )
+
+if (-not $Token) { $Token = $env:HERALD_ADMIN_TOKEN }
+if (-not $Token) { Write-Error "Provide -Token or set `$env:HERALD_ADMIN_TOKEN"; return }
 
 if ($Seconds -lt 1) {
     Write-Error "Interval must be at least 1 second."


### PR DESCRIPTION
## Description

Complete the Phase 4 terminal animation experience with ANSI 256-color support, rendering optimizations, animation speed control, and improved PowerShell helper scripts.

### What's included

- **ANSI 256-color tiles (#33)** — color tiles now use indexed ANSI 256-color codes (Red→196, Orange→208, etc.) for consistent rendering across terminals. White and Black tiles get contrasting foreground colors. Automatic fallback to basic 8-color mode when `TERM`/`COLORTERM` indicate limited support.
- **Rendering optimization (#36)** — animation no longer allocates a new `DisplayGrid` every frame. A `sample_into()` method writes directly into a pre-allocated buffer, and frame-skip logic prevents rendering pile-up when the loop falls behind. `cycling_steps` Vec is pre-allocated.
- **Animation speed flag (#37)** — `--animation-speed` on `herald watch` accepts `fast` (25ms/10ms), `normal` (50ms/20ms, default), `slow` (100ms/40ms), or `off` (instant transitions). `off` mode skips animation entirely.
- **PowerShell script improvements** — all scripts now auto-detect `` so `-Token` is optional. New `list-queue.ps1` script shows all messages and countdowns in the rotation with type, label, ID, and expiry info.

## Related Issues

Closes #33, Closes #36, Closes #37

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)