### PR TITLE
feat: add web viewer with Leptos CSR, split-flap animations, and WebSocket client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All PowerShell scripts auto-detect `$env:HERALD_ADMIN_TOKEN`, removing the need to pass `-Token` every time
 - `add-color-message.ps1` script to push messages with colored tile fills (`-Color`, `-FillRows`, `-BgColor`)
 - `remove-countdown.ps1` script to remove countdowns by ID or all at once
+- Web viewer crate (`herald-web`) with Leptos CSR and Trunk build tooling
+- WebSocket client for the browser with auto-detected server URL and exponential backoff reconnection
+- 6×22 split-flap board grid rendered with CSS Grid, dark theme, and 3D perspective tilt
+- Split-flap tile component with top/bottom half rendering and visible horizontal split line
+- 3D CSS flip animation on board transitions (150ms per flap, top-half rotates away then bottom-half drops in)
+- Left-to-right cascade stagger effect on web flip animations (20ms column delay, ~615ms full board)
+- Color tile rendering with 8 Vestaboard-compatible colors mapped to CSS custom properties for theming
+- Connection status bar with live connected/reconnecting indicator
+- Responsive board layout with mobile horizontal scroll and large-screen centering
+- Loading shimmer animation for tiles before WebSocket connection is established
+- Fine-grained reactive signals (one per cell) for optimal re-render performance — only changed cells update
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_spawner"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41058deaa38c9d9dd933d6d238d825227cffa668e2839b52879f6619c63eee3b"
+dependencies = [
+ "futures",
+ "thiserror 2.0.18",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "atoi"
@@ -96,6 +129,36 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn",
+]
 
 [[package]]
 name = "autocfg"
@@ -207,6 +270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +361,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "codee"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dbbdc4b4d349732bc6690de10a9de952bd39ba6a065c586e26600b6b0b91f5"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,10 +407,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.15.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+dependencies = [
+ "convert_case 0.6.0",
+ "pathdiff",
+ "serde_core",
+ "toml",
+ "winnow",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "const_str_slice_concat"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67855af358fcb20fac58f9d714c94e2b228fe5694c1c9b4ead4a366343eda1b"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -461,6 +624,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +652,17 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -507,12 +695,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "drain_filter_polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "either_of"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f86eef3a7e4b9c2107583dbbbe3d9535c4b800796faf1774b82ba22033da"
+dependencies = [
+ "paste",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -559,6 +769,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -619,6 +839,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -694,6 +929,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -751,6 +987,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "guardian"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +1056,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -840,7 +1134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower",
@@ -848,6 +1142,27 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "herald-web"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "console_log",
+ "futures",
+ "gloo-net",
+ "gloo-timers",
+ "herald-common",
+ "js-sys",
+ "leptos",
+ "log",
+ "serde",
+ "serde_json",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -881,6 +1196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -927,6 +1251,20 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hydration_context"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35485b3dcbf7e044b8f28c73f04f13e7b509c2466fd10cb2a8a447e38f8a93a"
+dependencies = [
+ "futures",
+ "once_cell",
+ "or_poisoned",
+ "pin-project-lite",
+ "serde",
+ "throw_error",
+]
 
 [[package]]
 name = "hyper"
@@ -1180,6 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1550,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1244,6 +1597,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "leptos"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b8731cb00f3f0894058155410b95c8955b17273181d2bc72600ab84edd24f1"
+dependencies = [
+ "any_spawner",
+ "cfg-if",
+ "either_of",
+ "futures",
+ "hydration_context",
+ "leptos_config",
+ "leptos_dom",
+ "leptos_hot_reload",
+ "leptos_macro",
+ "leptos_server",
+ "oco_ref",
+ "or_poisoned",
+ "paste",
+ "reactive_graph",
+ "rustc-hash",
+ "send_wrapper",
+ "serde",
+ "serde_qs",
+ "server_fn",
+ "slotmap",
+ "tachys",
+ "thiserror 2.0.18",
+ "throw_error",
+ "typed-builder",
+ "typed-builder-macro",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "leptos_config"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bae3e0ead5a7a814c8340eef7cb8b6cba364125bd8174b15dc9fe1b3cab7e03"
+dependencies = [
+ "config",
+ "regex",
+ "serde",
+ "thiserror 2.0.18",
+ "typed-builder",
+]
+
+[[package]]
+name = "leptos_dom"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89d4eb263bd5a9e7c49f780f17063f15aca56fd638c90b9dfd5f4739152e87d"
+dependencies = [
+ "js-sys",
+ "or_poisoned",
+ "reactive_graph",
+ "send_wrapper",
+ "tachys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "leptos_hot_reload"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80219388501d99b246f43b6e7d08a28f327cdd34ba630a35654d917f3e1788e"
+dependencies = [
+ "anyhow",
+ "camino",
+ "indexmap",
+ "parking_lot",
+ "proc-macro2",
+ "quote",
+ "rstml",
+ "serde",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "leptos_macro"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e621f8f5342b9bdc93bb263b839cee7405027a74560425a2dabea9de7952b1fd"
+dependencies = [
+ "attribute-derive",
+ "cfg-if",
+ "convert_case 0.7.1",
+ "html-escape",
+ "itertools 0.14.0",
+ "leptos_hot_reload",
+ "prettyplease",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "rstml",
+ "server_fn_macro",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "leptos_server"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66985242812ec95e224fb48effe651ba02728beca92c461a9464c811a71aab11"
+dependencies = [
+ "any_spawner",
+ "base64",
+ "codee",
+ "futures",
+ "hydration_context",
+ "or_poisoned",
+ "reactive_graph",
+ "send_wrapper",
+ "serde",
+ "serde_json",
+ "server_fn",
+ "tachys",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1753,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linear-map"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1318,6 +1800,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1387,6 +1892,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "next_tuple"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1950,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "oco_ref"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0423ff9973dea4d6bd075934fdda86ebb8c05bdf9d6b0507067d4a1226371d"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1498,6 +2019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "or_poisoned"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +2060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +2079,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1615,6 +2168,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,12 +2210,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1715,13 +2336,62 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "reactive_graph"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a0ccddbc11a648bd09761801dac9e3f246ef7641130987d6120fced22515e6"
+dependencies = [
+ "any_spawner",
+ "async-lock",
+ "futures",
+ "guardian",
+ "hydration_context",
+ "or_poisoned",
+ "pin-project-lite",
+ "rustc-hash",
+ "send_wrapper",
+ "serde",
+ "slotmap",
+ "thiserror 2.0.18",
+ "web-sys",
+]
+
+[[package]]
+name = "reactive_stores"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadc7c19e3a360bf19cd595d2dc8b58ce67b9240b95a103fbc1317a8ff194237"
+dependencies = [
+ "guardian",
+ "itertools 0.14.0",
+ "or_poisoned",
+ "paste",
+ "reactive_graph",
+ "reactive_stores_macro",
+ "rustc-hash",
+]
+
+[[package]]
+name = "reactive_stores_macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221095cb028dc51fbc2833743ea8b1a585da1a2af19b440b3528027495bf1f2d"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1740,6 +2410,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1834,6 +2516,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstml"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61cf4616de7499fc5164570d40ca4e1b24d231c6833a88bff0fe00725080fd56"
+dependencies = [
+ "derive-where",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+ "syn_derive",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +2608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2659,15 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "serde"
@@ -2003,6 +2724,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2753,60 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "server_fn"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d05a9e3fd8d7404985418db38c6617cc793a1a27f398d4fbc9dfe8e41b804e6"
+dependencies = [
+ "bytes",
+ "const_format",
+ "dashmap",
+ "futures",
+ "gloo-net",
+ "http",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "send_wrapper",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "server_fn_macro_default",
+ "thiserror 2.0.18",
+ "throw_error",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "server_fn_macro"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504b35e883267b3206317b46d02952ed7b8bf0e11b2e209e2eb453b609a5e052"
+dependencies = [
+ "const_format",
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "server_fn_macro_default"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8b274f568c94226a8045668554aace8142a59b8bca5414ac5a79627c825568"
+dependencies = [
+ "server_fn_macro",
+ "syn",
 ]
 
 [[package]]
@@ -2099,6 +2894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,7 +2981,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2261,7 +3065,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2300,7 +3104,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -2326,7 +3130,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -2401,6 +3205,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2442,6 +3258,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tachys"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66c3b70c32844a6f1e2943c72a33ebb777ad6acbeb20d1329d62e3a7806d6ec"
+dependencies = [
+ "any_spawner",
+ "async-trait",
+ "const_str_slice_concat",
+ "drain_filter_polyfill",
+ "dyn-clone",
+ "either_of",
+ "futures",
+ "html-escape",
+ "indexmap",
+ "itertools 0.14.0",
+ "js-sys",
+ "linear-map",
+ "next_tuple",
+ "oco_ref",
+ "once_cell",
+ "or_poisoned",
+ "parking_lot",
+ "paste",
+ "reactive_graph",
+ "reactive_stores",
+ "rustc-hash",
+ "send_wrapper",
+ "slotmap",
+ "throw_error",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,11 +3306,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2481,6 +3351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "throw_error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ef8bf264c6ae02a065a4a16553283f0656bd6266fc1fcb09fd2e6b5e91427b"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2602,6 +3481,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2745,7 +3655,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -2762,7 +3672,27 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2810,7 +3740,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -2858,6 +3788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,6 +3834,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3016,6 +3962,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3062,6 +4021,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3297,6 +4265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +4366,18 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["crates/herald-common", "crates/herald-server", "crates/herald-cli"]
+members = ["crates/herald-common", "crates/herald-server", "crates/herald-cli", "crates/herald-web"]
+default-members = ["crates/herald-common", "crates/herald-server", "crates/herald-cli"]
 
 [workspace.package]
 version = "0.1.0"
@@ -43,6 +44,19 @@ thiserror = "2"
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.29"
 crossterm = "0.28"
+
+# Web (Leptos + Wasm)
+leptos = { version = "0.7", features = ["csr"] }
+gloo-net = { version = "0.6", features = ["websocket"] }
+gloo-timers = { version = "0.3", features = ["futures"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["Window", "Location"] }
+js-sys = "0.3"
+log = "0.4"
+console_log = "1"
+console_error_panic_hook = "0.1"
+futures = "0.3"
 
 # Internal crates
 herald-common = { path = "crates/herald-common" }

--- a/crates/herald-web/Cargo.toml
+++ b/crates/herald-web/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "herald-web"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Web viewer for the Herald split-flap message board"
+
+[dependencies]
+herald-common = { workspace = true }
+uuid = { workspace = true, features = ["js"] }
+leptos = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+gloo-net = { workspace = true }
+gloo-timers = { workspace = true }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+web-sys = { workspace = true }
+js-sys = { workspace = true }
+log = { workspace = true }
+console_log = { workspace = true }
+console_error_panic_hook = { workspace = true }
+futures = { workspace = true }

--- a/crates/herald-web/Trunk.toml
+++ b/crates/herald-web/Trunk.toml
@@ -1,0 +1,6 @@
+[build]
+target = "index.html"
+dist = "dist"
+
+[watch]
+watch = ["src", "index.html"]

--- a/crates/herald-web/index.html
+++ b/crates/herald-web/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Herald — Split-Flap Message Board</title>
+    <link data-trunk rel="rust" data-wasm-opt="z" />
+    <style>
+        /* ===== Reset & Base ===== */
+        *, *::before, *::after {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        :root {
+            /* Board dimensions */
+            --board-cols: 22;
+            --board-rows: 6;
+            --tile-gap: 2px;
+
+            /* Tile sizing */
+            --tile-width: clamp(1.5rem, 3vw, 2.8rem);
+            --tile-height: clamp(2rem, 4vw, 3.6rem);
+
+            /* Colors */
+            --board-bg: #1a1a1a;
+            --tile-top-bg: #2c2c2c;
+            --tile-bottom-bg: #262626;
+            --tile-char-color: #f0f0f0;
+            --tile-split-line: #111;
+            --board-shadow: rgba(0, 0, 0, 0.4);
+
+            /* Color tiles */
+            --color-red: #D32F2F;
+            --color-orange: #F57C00;
+            --color-yellow: #FDD835;
+            --color-green: #388E3C;
+            --color-blue: #1565C0;
+            --color-violet: #7B1FA2;
+            --color-white: #F5F5F5;
+            --color-black: #212121;
+
+            /* Animation timing */
+            --flip-duration: 150ms;
+            --stagger-delay: 20ms;
+        }
+
+        body {
+            background: #0d0d0d;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            font-family: system-ui, -apple-system, sans-serif;
+            color: #f0f0f0;
+            overflow: hidden;
+        }
+
+        /* ===== Board Container ===== */
+        .herald-board {
+            perspective: 1200px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .board-grid {
+            display: grid;
+            grid-template-columns: repeat(var(--board-cols), var(--tile-width));
+            grid-template-rows: repeat(var(--board-rows), var(--tile-height));
+            gap: var(--tile-gap);
+            padding: 1rem;
+            background: var(--board-bg);
+            border-radius: 8px;
+            box-shadow:
+                0 4px 12px var(--board-shadow),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05);
+            transform: perspective(1200px) rotateX(2deg);
+        }
+
+        /* ===== Flap Tile ===== */
+        .flap-tile {
+            position: relative;
+            width: var(--tile-width);
+            height: var(--tile-height);
+            perspective: 300px;
+            transform-style: preserve-3d;
+            will-change: transform;
+            contain: layout style paint;
+            box-shadow:
+                0 1px 3px rgba(0, 0, 0, 0.3),
+                0 0 0 1px rgba(0, 0, 0, 0.15);
+        }
+
+        .flap-tile--idle {
+            will-change: auto;
+        }
+
+        .flap-tile .flap-char {
+            font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+            font-size: clamp(0.9rem, 1.8vw, 1.6rem);
+            font-weight: 700;
+            color: var(--tile-char-color);
+            line-height: 1;
+            user-select: none;
+        }
+
+        /* Top and bottom halves */
+        .flap-top,
+        .flap-bottom {
+            position: absolute;
+            left: 0;
+            right: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            backface-visibility: hidden;
+            -webkit-backface-visibility: hidden;
+        }
+
+        .flap-top {
+            top: 0;
+            height: 50%;
+            background: var(--tile-top-bg);
+            border-radius: 4px 4px 0 0;
+            border-bottom: 1px solid var(--tile-split-line);
+            clip-path: inset(0 0 0 0);
+        }
+
+        .flap-top .flap-char {
+            transform: translateY(50%);
+        }
+
+        .flap-bottom {
+            bottom: 0;
+            height: 50%;
+            background: var(--tile-bottom-bg);
+            border-radius: 0 0 4px 4px;
+            clip-path: inset(0 0 0 0);
+        }
+
+        .flap-bottom .flap-char {
+            transform: translateY(-50%);
+        }
+
+        /* ===== Flip Keyframes ===== */
+        @keyframes flap-top-flip {
+            0% { transform: rotateX(0deg); }
+            100% { transform: rotateX(-90deg); }
+        }
+
+        @keyframes flap-bottom-flip {
+            0% { transform: rotateX(90deg); }
+            100% { transform: rotateX(0deg); }
+        }
+
+        .flap-top--flipping {
+            animation: flap-top-flip var(--flip-duration) ease-in forwards;
+            transform-origin: bottom center;
+        }
+
+        .flap-bottom-flip {
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 50%;
+            background: var(--tile-top-bg);
+            border-radius: 0 0 4px 4px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            overflow: hidden;
+            backface-visibility: hidden;
+            -webkit-backface-visibility: hidden;
+            transform-origin: top center;
+            animation: flap-bottom-flip var(--flip-duration) ease-out var(--flip-duration) forwards;
+            transform: rotateX(90deg);
+        }
+
+        .flap-bottom-flip .flap-char {
+            transform: translateY(-50%);
+        }
+
+        /* Enhanced shadow during flip */
+        .flap-top--flipping,
+        .flap-bottom-flip {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+        }
+
+        /* Static top (new char after animation) */
+        .flap-top--static {
+            transform: rotateX(0deg);
+        }
+
+        /* ===== Cascade Stagger ===== */
+        .flap-top--flipping,
+        .flap-bottom-flip {
+            animation-delay: calc(var(--col-index, 0) * var(--stagger-delay));
+        }
+        .flap-bottom-flip {
+            animation-delay: calc(var(--col-index, 0) * var(--stagger-delay) + var(--flip-duration));
+        }
+
+        /* ===== Color Tiles ===== */
+        .flap-tile--color .flap-top,
+        .flap-tile--color .flap-bottom,
+        .flap-tile--color .flap-bottom-flip {
+            border-bottom: none;
+            border-radius: 4px;
+        }
+
+        .flap-tile--color .flap-char {
+            display: none;
+        }
+
+        /* Dark text for light color tiles */
+        .flap-tile--light .flap-char {
+            color: #212121;
+        }
+
+        /* ===== Loading State ===== */
+        @keyframes tile-shimmer {
+            0% { opacity: 0.3; }
+            50% { opacity: 0.6; }
+            100% { opacity: 0.3; }
+        }
+
+        .flap-tile--loading .flap-top,
+        .flap-tile--loading .flap-bottom {
+            background: var(--board-bg);
+            animation: tile-shimmer 1.5s ease-in-out infinite;
+        }
+
+        /* ===== Status Bar ===== */
+        .board-status {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.85rem;
+            color: #888;
+            padding: 0.25rem 0.5rem;
+        }
+
+        .status-indicator {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #555;
+        }
+
+        .status-indicator.connected {
+            background: #4caf50;
+        }
+
+        .status-indicator.connecting {
+            background: #ff9800;
+            animation: pulse 1s ease-in-out infinite;
+        }
+
+        .status-indicator.disconnected {
+            background: #f44336;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.4; }
+        }
+
+        /* ===== Responsive ===== */
+        @media (max-width: 480px) {
+            .herald-board {
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+            }
+            .board-grid {
+                min-width: 33rem;
+            }
+        }
+
+        @media (min-width: 1200px) {
+            .herald-board {
+                max-width: 65rem;
+                margin: 0 auto;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Leptos will mount here -->
+</body>
+</html>

--- a/crates/herald-web/src/components/board.rs
+++ b/crates/herald-web/src/components/board.rs
@@ -1,0 +1,28 @@
+use super::tile::FlapTile;
+use crate::ws::WebSocketState;
+use herald_common::{BOARD_COLS, BOARD_ROWS};
+use leptos::prelude::*;
+
+/// The main board grid component.
+/// Renders a 6×22 grid of FlapTile components using CSS Grid.
+#[component]
+pub fn Board(ws_state: WebSocketState) -> impl IntoView {
+    view! {
+        <div class="board-grid">
+            {(0..BOARD_ROWS).map(|row| {
+                let ws = ws_state.clone();
+                (0..BOARD_COLS).map(move |col| {
+                    let ws = ws.clone();
+                    view! {
+                        <FlapTile
+                            cell=ws.grid[row][col]
+                            prev_cell=ws.previous_grid[row][col]
+                            col_index=col
+                            update_counter=ws.update_counter
+                        />
+                    }
+                }).collect_view()
+            }).collect_view()}
+        </div>
+    }
+}

--- a/crates/herald-web/src/components/mod.rs
+++ b/crates/herald-web/src/components/mod.rs
@@ -1,0 +1,4 @@
+mod board;
+mod tile;
+
+pub use board::Board;

--- a/crates/herald-web/src/components/tile.rs
+++ b/crates/herald-web/src/components/tile.rs
@@ -1,0 +1,132 @@
+use herald_common::{CellContent, Color};
+use leptos::prelude::*;
+
+/// Convert a CellContent to its display character.
+fn cell_to_char(cell: &CellContent) -> String {
+    match cell {
+        CellContent::Char(c) => c.to_string(),
+        CellContent::Blank => " ".to_string(),
+        CellContent::Color(_) => String::new(),
+    }
+}
+
+/// Get CSS background color for a Color tile.
+fn color_to_css(color: &Color) -> &'static str {
+    match color {
+        Color::Red => "var(--color-red)",
+        Color::Orange => "var(--color-orange)",
+        Color::Yellow => "var(--color-yellow)",
+        Color::Green => "var(--color-green)",
+        Color::Blue => "var(--color-blue)",
+        Color::Violet => "var(--color-violet)",
+        Color::White => "var(--color-white)",
+        Color::Black => "var(--color-black)",
+    }
+}
+
+/// Whether a color tile needs dark text (for light backgrounds).
+fn is_light_color(color: &Color) -> bool {
+    matches!(color, Color::White | Color::Yellow)
+}
+
+/// A single split-flap tile component.
+///
+/// Renders the top/bottom halves of a mechanical flap tile with 3D flip animation.
+/// Uses `--col-index` CSS variable for cascade stagger delay.
+#[component]
+pub fn FlapTile(
+    cell: RwSignal<CellContent>,
+    prev_cell: RwSignal<CellContent>,
+    col_index: usize,
+    update_counter: RwSignal<u64>,
+) -> impl IntoView {
+    let is_animating = RwSignal::new(false);
+
+    // When update_counter changes, check if this cell actually changed and trigger animation
+    Effect::new(move |prev_count: Option<u64>| {
+        let count = update_counter.get();
+        if prev_count.is_some() {
+            let current = cell.get();
+            let previous = prev_cell.get();
+            if current != previous {
+                is_animating.set(true);
+                let delay_ms = (col_index as u32) * 20 + 350;
+                set_timeout(
+                    move || is_animating.set(false),
+                    std::time::Duration::from_millis(delay_ms as u64),
+                );
+            }
+        }
+        count
+    });
+
+    let tile_class = move || {
+        let c = cell.get();
+        let mut classes = vec!["flap-tile"];
+        if let CellContent::Color(color) = &c {
+            classes.push("flap-tile--color");
+            if is_light_color(color) {
+                classes.push("flap-tile--light");
+            }
+        }
+        if !is_animating.get() {
+            classes.push("flap-tile--idle");
+        }
+        classes.join(" ")
+    };
+
+    let tile_style = move || {
+        let mut style = format!("--col-index: {col_index};");
+        if let CellContent::Color(color) = cell.get() {
+            let css_color = color_to_css(&color);
+            style.push_str(&format!(" --tile-bg: {css_color};"));
+        }
+        style
+    };
+
+    let half_bg_style = move || {
+        if let CellContent::Color(color) = cell.get() {
+            format!("background: {};", color_to_css(&color))
+        } else {
+            String::new()
+        }
+    };
+
+    let old_char = move || cell_to_char(&prev_cell.get());
+    let new_char = move || cell_to_char(&cell.get());
+
+    view! {
+        <div class=tile_class style=tile_style>
+            // Static bottom layer: shows the NEW character underneath
+            <div class="flap-bottom" style=half_bg_style>
+                <span class="flap-char">{new_char}</span>
+            </div>
+
+            // Animated layers (only rendered during animation)
+            {move || {
+                if is_animating.get() {
+                    let old_c = old_char();
+                    let new_c = new_char();
+                    let bg = half_bg_style();
+                    Some(view! {
+                        // Old top half flipping away
+                        <div class="flap-top flap-top--flipping" style=bg.clone()>
+                            <span class="flap-char">{old_c}</span>
+                        </div>
+                        // New bottom half flipping into place
+                        <div class="flap-bottom-flip" style=bg>
+                            <span class="flap-char">{new_c}</span>
+                        </div>
+                    })
+                } else {
+                    None
+                }
+            }}
+
+            // Static top layer: shows the NEW character (always visible)
+            <div class="flap-top flap-top--static" style=half_bg_style>
+                <span class="flap-char">{new_char}</span>
+            </div>
+        </div>
+    }
+}

--- a/crates/herald-web/src/main.rs
+++ b/crates/herald-web/src/main.rs
@@ -1,0 +1,50 @@
+mod components;
+mod ws;
+
+use components::Board;
+use leptos::prelude::*;
+use ws::WebSocketState;
+
+/// Root application component.
+#[component]
+fn App() -> impl IntoView {
+    let ws_state = ws::use_websocket();
+
+    view! {
+        <div class="herald-board" role="img" aria-label="Herald message board">
+            <Board ws_state=ws_state.clone() />
+            <StatusBar ws_state=ws_state />
+        </div>
+    }
+}
+
+/// Connection status bar below the board.
+#[component]
+fn StatusBar(ws_state: WebSocketState) -> impl IntoView {
+    let status_class = move || match ws_state.connected.get() {
+        true => "status-indicator connected",
+        false => "status-indicator connecting",
+    };
+
+    let status_text = move || {
+        if ws_state.connected.get() {
+            "Connected".to_string()
+        } else {
+            "Reconnecting...".to_string()
+        }
+    };
+
+    view! {
+        <div class="board-status">
+            <span class=status_class></span>
+            <span class="status-text">{status_text}</span>
+        </div>
+    }
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+    _ = console_log::init_with_level(log::Level::Debug);
+    log::info!("Herald web viewer starting...");
+    leptos::mount::mount_to_body(App);
+}

--- a/crates/herald-web/src/ws.rs
+++ b/crates/herald-web/src/ws.rs
@@ -1,0 +1,162 @@
+use futures::StreamExt;
+use gloo_net::websocket::{Message, futures::WebSocket};
+use gloo_timers::future::TimeoutFuture;
+use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent, ServerMessage};
+use leptos::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+
+/// State exposed from the WebSocket connection to UI components.
+#[derive(Clone)]
+pub struct WebSocketState {
+    /// Current grid — 6×22 grid of signals, one per cell
+    pub grid: Vec<Vec<RwSignal<CellContent>>>,
+    /// Previous grid for animation diffing
+    pub previous_grid: Vec<Vec<RwSignal<CellContent>>>,
+    /// Whether we're currently connected
+    pub connected: RwSignal<bool>,
+    /// Trigger signal that increments on each board update (used to start animations)
+    pub update_counter: RwSignal<u64>,
+}
+
+/// Derive the WebSocket URL from the current page location.
+fn ws_url() -> String {
+    let window = web_sys::window().expect("no window");
+    let location = window.location();
+    let protocol = location.protocol().unwrap_or_else(|_| "http:".into());
+    let host = location.host().unwrap_or_else(|_| "localhost:3000".into());
+    let ws_protocol = if protocol == "https:" { "wss:" } else { "ws:" };
+    format!("{ws_protocol}//{host}/ws")
+}
+
+/// Create and manage a WebSocket connection with reconnection logic.
+/// Returns reactive state that updates when board state changes.
+pub fn use_websocket() -> WebSocketState {
+    let grid: Vec<Vec<RwSignal<CellContent>>> = (0..BOARD_ROWS)
+        .map(|_| {
+            (0..BOARD_COLS)
+                .map(|_| RwSignal::new(CellContent::Blank))
+                .collect()
+        })
+        .collect();
+
+    let previous_grid: Vec<Vec<RwSignal<CellContent>>> = (0..BOARD_ROWS)
+        .map(|_| {
+            (0..BOARD_COLS)
+                .map(|_| RwSignal::new(CellContent::Blank))
+                .collect()
+        })
+        .collect();
+
+    let connected = RwSignal::new(false);
+    let update_counter = RwSignal::new(0u64);
+
+    let state = WebSocketState {
+        grid,
+        previous_grid,
+        connected,
+        update_counter,
+    };
+
+    let state_clone = state.clone();
+    spawn_local(async move {
+        connection_loop(state_clone).await;
+    });
+
+    state
+}
+
+/// Reconnection loop with exponential backoff.
+async fn connection_loop(state: WebSocketState) {
+    let mut attempt: u32 = 0;
+
+    loop {
+        let url = ws_url();
+        log::info!("WebSocket connecting to {url} (attempt {attempt})...");
+
+        match WebSocket::open(&url) {
+            Ok(ws) => {
+                attempt = 0;
+                state.connected.set(true);
+                log::info!("WebSocket connected");
+
+                let (_write, mut read) = ws.split();
+
+                while let Some(msg) = read.next().await {
+                    match msg {
+                        Ok(Message::Text(text)) => {
+                            handle_message(&text, &state);
+                        }
+                        Ok(Message::Bytes(bytes)) => {
+                            if let Ok(text) = String::from_utf8(bytes) {
+                                handle_message(&text, &state);
+                            }
+                        }
+                        Err(e) => {
+                            log::error!("WebSocket error: {e:?}");
+                            break;
+                        }
+                    }
+                }
+
+                state.connected.set(false);
+                log::warn!("WebSocket disconnected");
+            }
+            Err(e) => {
+                log::error!("WebSocket connection failed: {e:?}");
+                state.connected.set(false);
+            }
+        }
+
+        // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s max
+        let delay_ms = std::cmp::min(1000 * 2u32.saturating_pow(attempt), 30_000);
+        log::info!("Reconnecting in {delay_ms}ms...");
+        TimeoutFuture::new(delay_ms).await;
+        attempt += 1;
+    }
+}
+
+/// Process a single incoming server message.
+fn handle_message(text: &str, state: &WebSocketState) {
+    match serde_json::from_str::<ServerMessage>(text) {
+        Ok(ServerMessage::BoardUpdate(board_state)) => {
+            apply_board_update(&board_state, state);
+        }
+        Ok(ServerMessage::Heartbeat { .. }) => {
+            log::trace!("Heartbeat received");
+        }
+        Ok(ServerMessage::QueueInfo { .. }) => {
+            // Could display in status bar — future enhancement
+        }
+        Ok(ServerMessage::Shutdown { reason }) => {
+            log::warn!("Server shutting down: {reason}");
+        }
+        Ok(ServerMessage::Error { message }) => {
+            log::error!("Server error: {message}");
+        }
+        Err(e) => {
+            log::warn!("Failed to parse server message: {e}");
+        }
+    }
+}
+
+/// Apply a board update to the reactive grid signals.
+fn apply_board_update(board_state: &BoardState, state: &WebSocketState) {
+    // Copy current grid to previous_grid signals before updating
+    for row in 0..BOARD_ROWS {
+        for col in 0..BOARD_COLS {
+            let current = state.grid[row][col].get_untracked();
+            state.previous_grid[row][col].set(current);
+        }
+    }
+
+    // Update grid signals — only cells that changed will trigger re-renders
+    for row in 0..BOARD_ROWS {
+        for col in 0..BOARD_COLS {
+            let new_cell = board_state.grid.0[row][col];
+            state.grid[row][col].set(new_cell);
+        }
+    }
+
+    // Increment update counter to trigger animations
+    state.update_counter.update(|c| *c += 1);
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Description

Add the herald-web crate — a Leptos CSR (client-side rendered) web viewer that connects to the Herald server via WebSocket and renders the 6×22 split-flap message board with 3D flip animations in the browser.

### What's included

- **Crate scaffold** — herald-web added to the workspace with Leptos 0.7 (CSR mode), Trunk build tooling, and wasm32-unknown-unknown target. Excluded from default-members so cargo build still works without the wasm target.
- **WebSocket client** (src/ws.rs) — Connects to /ws, auto-detects the URL from window.location, deserializes ServerMessage JSON, and exposes the board as 132 fine-grained RwSignal<CellContent> signals for optimal reactivity. Implements exponential backoff reconnection (1s → 30s max).
- **Board grid** (src/components/board.rs) — CSS Grid layout for 6×22 tiles with dark surround, rounded corners, subtle 3D perspective tilt, and responsive scaling.
- **Split-flap tile** (src/components/tile.rs) — Top/bottom half rendering with visible split line, transform-style: preserve-3d, and per-cell animation state tracking.
- **Flip animation** — CSS @keyframes for the 3D flip sequence: top half rotates backward (-90°), then bottom half drops into place (90° → 0°). 150ms per step.
- **Cascade stagger** — Left-to-right wave effect via --col-index CSS variable (column × 20ms delay). Full board transition completes in ~615ms.
- **Color tiles** — 8 Vestaboard colors mapped to CSS custom properties (--color-red through --color-black) with automatic dark/light text contrast.
- **Status bar** — Shows connection state (connected/reconnecting) with a colored indicator dot.
- **Loading state** — Shimmer animation on tiles before the WebSocket connects.

## Related Issues

Closes #38, closes #39, closes #40, closes #41, closes #42, closes #43, closes #44

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)