### PR TITLE
feat: add responsive scaling, loading state, reconnection UX, and static asset serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.db-wal
 *.db-shm
 herald_test_*
+web-dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Responsive board layout with mobile horizontal scroll and large-screen centering
 - Loading shimmer animation for tiles before WebSocket connection is established
 - Fine-grained reactive signals (one per cell) for optimal re-render performance — only changed cells update
+- Responsive board scaling: tiles auto-size to fit the viewport at any screen width (375px–1440px+) without scrolling
+- Loading state with gradient shimmer animation while the WebSocket connection is being established
+- Flip animation on initial connect: all tiles animate from blank to their first board state with cascade stagger
+- Connection status indicator (bottom-right pill): green when connected (auto-hides after 3s), yellow while connecting, red when reconnecting
+- Static web asset serving from `herald-server` via `HERALD_WEB_DIR` env var (default `./web-dist`), with SPA fallback routing
+- `build-web.ps1` script to compile `herald-web` with Trunk and copy output to `web-dist/`
 
 ### Changed
 
 - Optimized animation rendering: pre-allocated display buffers and frame-skip logic for smooth 30fps playback
 - Color tiles now animate with a split-flap color cycling effect on board transitions, flipping through intermediate colors (e.g., Red → Orange → Yellow → Green → Blue) instead of snapping instantly
+- Web board now scales responsively to always fit the viewport without scrolling (replaced mobile horizontal scroll with viewport-based tile sizing)
+- Web loading state now uses a gradient shimmer sweep and triggers flip animation on all tiles when the first board update arrives
+- Web connection status indicator repositioned to a fixed bottom-right pill that auto-hides 3 seconds after connecting
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1867,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -3538,11 +3554,20 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3700,6 +3725,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 # Web framework
 axum = { version = "0.8", features = ["json", "ws"] }
 tower = { version = "0.5" }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "fs"] }
 tokio-tungstenite = "0.26"
 futures-util = "0.3"
 

--- a/crates/herald-server/src/lib.rs
+++ b/crates/herald-server/src/lib.rs
@@ -284,7 +284,12 @@ pub fn start_cleanup_task(state: AppState) -> tokio::task::JoinHandle<()> {
 }
 
 /// Build the full Axum router with all routes.
-pub fn build_router(state: AppState) -> Router {
+///
+/// When `web_dir` is `Some` and the directory exists, static files from that
+/// directory are served as a fallback for any path that doesn't match an API or
+/// WebSocket route. `index.html` is returned for unknown paths to support SPA
+/// client-side routing.
+pub fn build_router(state: AppState, web_dir: Option<std::path::PathBuf>) -> Router {
     // Admin routes — protected by bearer token auth
     let admin_api = Router::new()
         // Messages
@@ -312,9 +317,27 @@ pub fn build_router(state: AppState) -> Router {
     // Public routes — no auth required
     let public_api = Router::new().route("/health", get(api::health::health));
 
-    Router::new()
+    let mut router = Router::new()
         .nest("/api", admin_api)
         .nest("/api", public_api)
         .route("/ws", get(ws::ws_upgrade))
-        .with_state(state)
+        .with_state(state);
+
+    // Serve static web assets if web_dir is configured and exists
+    if let Some(dir) = web_dir {
+        if dir.exists() {
+            tracing::info!("Serving web assets from {}", dir.display());
+            let serve_dir = tower_http::services::ServeDir::new(&dir)
+                .append_index_html_on_directories(true)
+                .fallback(tower_http::services::ServeFile::new(dir.join("index.html")));
+            router = router.fallback_service(serve_dir);
+        } else {
+            tracing::warn!(
+                "Web directory {} does not exist, static file serving disabled",
+                dir.display()
+            );
+        }
+    }
+
+    router
 }

--- a/crates/herald-server/src/main.rs
+++ b/crates/herald-server/src/main.rs
@@ -34,11 +34,24 @@ async fn main() {
 
     tracing::info!("Database initialized at {db_path}");
 
+    // Resolve web assets directory
+    let web_dir = env::var("HERALD_WEB_DIR")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            let default = std::path::PathBuf::from("./web-dist");
+            if default.exists() {
+                Some(default)
+            } else {
+                None
+            }
+        });
+
     // Build app
     let state = AppState::new(pool, admin_token);
     herald_server::start_rotation_task(state.clone());
     herald_server::start_cleanup_task(state.clone());
-    let app = build_router(state);
+    let app = build_router(state, web_dir);
 
     // Start server
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))

--- a/crates/herald-server/tests/api_tests.rs
+++ b/crates/herald-server/tests/api_tests.rs
@@ -16,7 +16,7 @@ async fn test_app() -> (axum::Router, String) {
     let database_url = format!("sqlite:{db_path}");
     let pool = db::init_pool(&database_url).await.unwrap();
     let state = AppState::new(pool, TEST_TOKEN.to_string());
-    let router = build_router(state);
+    let router = build_router(state, None);
     (router, db_path)
 }
 
@@ -683,7 +683,7 @@ async fn ws_broadcast_delivers_message() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -733,7 +733,7 @@ async fn ws_broadcast_on_message_create() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -795,7 +795,7 @@ async fn ws_broadcast_on_message_delete() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -871,7 +871,7 @@ async fn ws_broadcast_on_countdown_create() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -934,7 +934,7 @@ async fn ws_initial_state_empty_board() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1001,7 +1001,7 @@ async fn ws_initial_state_with_existing_message() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1082,7 +1082,7 @@ async fn rotation_advance_cycles_through_queue() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1166,7 +1166,7 @@ async fn rotation_skips_and_deletes_expired_messages() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1250,7 +1250,7 @@ async fn rotation_all_expired_results_in_empty_board() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -1318,7 +1318,7 @@ async fn countdown_renders_on_board_state() {
     let database_url = format!("sqlite:{db_path}");
     let pool = herald_server::db::init_pool(&database_url).await.unwrap();
     let state = herald_server::state::AppState::new(pool, TEST_TOKEN.to_string());
-    let app = herald_server::build_router(state.clone());
+    let app = herald_server::build_router(state.clone(), None);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/herald-web/index.html
+++ b/crates/herald-web/index.html
@@ -19,9 +19,9 @@
             --board-rows: 6;
             --tile-gap: 2px;
 
-            /* Tile sizing */
-            --tile-width: clamp(1.5rem, 3vw, 2.8rem);
-            --tile-height: clamp(2rem, 4vw, 3.6rem);
+            /* Tile sizing — viewport-based to always fit 22 columns */
+            --tile-width: clamp(1rem, calc((100vw - 3rem - 21 * 2px) / 22), 2.8rem);
+            --tile-height: clamp(1.3rem, calc((100vw - 3rem - 21 * 2px) / 22 * 1.3), 3.6rem);
 
             /* Colors */
             --board-bg: #1a1a1a;
@@ -100,7 +100,7 @@
 
         .flap-tile .flap-char {
             font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
-            font-size: clamp(0.9rem, 1.8vw, 1.6rem);
+            font-size: clamp(0.6rem, calc((100vw - 3rem) / 22 * 0.6), 1.6rem);
             font-weight: 700;
             color: var(--tile-char-color);
             line-height: 1;
@@ -224,25 +224,49 @@
 
         /* ===== Loading State ===== */
         @keyframes tile-shimmer {
-            0% { opacity: 0.3; }
-            50% { opacity: 0.6; }
-            100% { opacity: 0.3; }
+            0% {
+                background-position: -200% 0;
+            }
+            100% {
+                background-position: 200% 0;
+            }
         }
 
         .flap-tile--loading .flap-top,
         .flap-tile--loading .flap-bottom {
-            background: var(--board-bg);
+            background: linear-gradient(
+                90deg,
+                var(--board-bg) 25%,
+                #2a2a2a 50%,
+                var(--board-bg) 75%
+            );
+            background-size: 200% 100%;
             animation: tile-shimmer 1.5s ease-in-out infinite;
         }
 
         /* ===== Status Bar ===== */
         .board-status {
+            position: fixed;
+            bottom: 1rem;
+            right: 1rem;
             display: flex;
             align-items: center;
             gap: 0.5rem;
-            font-size: 0.85rem;
+            font-size: 0.8rem;
             color: #888;
-            padding: 0.25rem 0.5rem;
+            padding: 0.4rem 0.75rem;
+            background: rgba(0, 0, 0, 0.7);
+            border-radius: 2rem;
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+            z-index: 100;
+            transition: opacity 0.3s ease, transform 0.3s ease;
+        }
+
+        .board-status.status-hidden {
+            opacity: 0;
+            pointer-events: none;
+            transform: translateY(0.5rem);
         }
 
         .status-indicator {
@@ -273,11 +297,16 @@
         /* ===== Responsive ===== */
         @media (max-width: 480px) {
             .herald-board {
-                overflow-x: auto;
-                -webkit-overflow-scrolling: touch;
+                padding: 0 0.25rem;
             }
             .board-grid {
-                min-width: 33rem;
+                padding: 0.5rem;
+            }
+        }
+
+        @media (min-width: 481px) and (max-width: 1199px) {
+            .board-grid {
+                padding: 0.75rem;
             }
         }
 

--- a/crates/herald-web/src/components/board.rs
+++ b/crates/herald-web/src/components/board.rs
@@ -19,6 +19,7 @@ pub fn Board(ws_state: WebSocketState) -> impl IntoView {
                             prev_cell=ws.previous_grid[row][col]
                             col_index=col
                             update_counter=ws.update_counter
+                            has_received_update=ws.has_received_update
                         />
                     }
                 }).collect_view()

--- a/crates/herald-web/src/components/tile.rs
+++ b/crates/herald-web/src/components/tile.rs
@@ -39,6 +39,7 @@ pub fn FlapTile(
     prev_cell: RwSignal<CellContent>,
     col_index: usize,
     update_counter: RwSignal<u64>,
+    has_received_update: RwSignal<bool>,
 ) -> impl IntoView {
     let is_animating = RwSignal::new(false);
 
@@ -46,6 +47,7 @@ pub fn FlapTile(
     Effect::new(move |prev_count: Option<u64>| {
         let count = update_counter.get();
         if prev_count.is_some() {
+            // Subsequent updates: only animate changed cells
             let current = cell.get();
             let previous = prev_cell.get();
             if current != previous {
@@ -56,6 +58,14 @@ pub fn FlapTile(
                     std::time::Duration::from_millis(delay_ms as u64),
                 );
             }
+        } else if has_received_update.get() {
+            // First update: animate all tiles from loading state
+            is_animating.set(true);
+            let delay_ms = (col_index as u32) * 20 + 350;
+            set_timeout(
+                move || is_animating.set(false),
+                std::time::Duration::from_millis(delay_ms as u64),
+            );
         }
         count
     });
@@ -68,6 +78,9 @@ pub fn FlapTile(
             if is_light_color(color) {
                 classes.push("flap-tile--light");
             }
+        }
+        if !has_received_update.get() {
+            classes.push("flap-tile--loading");
         }
         if !is_animating.get() {
             classes.push("flap-tile--idle");

--- a/crates/herald-web/src/main.rs
+++ b/crates/herald-web/src/main.rs
@@ -13,21 +13,57 @@ fn App() -> impl IntoView {
     view! {
         <div class="herald-board" role="img" aria-label="Herald message board">
             <Board ws_state=ws_state.clone() />
-            <StatusBar ws_state=ws_state />
         </div>
+        <StatusBar ws_state=ws_state />
     }
 }
 
-/// Connection status bar below the board.
+/// Fixed-position connection status indicator (bottom-right).
+/// Auto-hides 3 seconds after a successful connection.
 #[component]
 fn StatusBar(ws_state: WebSocketState) -> impl IntoView {
-    let status_class = move || match ws_state.connected.get() {
-        true => "status-indicator connected",
-        false => "status-indicator connecting",
+    let is_visible = RwSignal::new(true);
+
+    // Auto-hide when connected for 3 seconds
+    Effect::new(move |_| {
+        let connected = ws_state.connected.get();
+        let has_update = ws_state.has_received_update.get();
+        if connected && has_update {
+            set_timeout(
+                move || {
+                    if ws_state.connected.get_untracked() {
+                        is_visible.set(false);
+                    }
+                },
+                std::time::Duration::from_secs(3),
+            );
+        } else {
+            is_visible.set(true);
+        }
+    });
+
+    let container_class = move || {
+        let mut classes = vec!["board-status"];
+        if !is_visible.get() {
+            classes.push("status-hidden");
+        }
+        classes.join(" ")
+    };
+
+    let indicator_class = move || {
+        if !ws_state.has_received_update.get() {
+            "status-indicator connecting"
+        } else if ws_state.connected.get() {
+            "status-indicator connected"
+        } else {
+            "status-indicator disconnected"
+        }
     };
 
     let status_text = move || {
-        if ws_state.connected.get() {
+        if !ws_state.has_received_update.get() {
+            "Connecting...".to_string()
+        } else if ws_state.connected.get() {
             "Connected".to_string()
         } else {
             "Reconnecting...".to_string()
@@ -35,8 +71,8 @@ fn StatusBar(ws_state: WebSocketState) -> impl IntoView {
     };
 
     view! {
-        <div class="board-status">
-            <span class=status_class></span>
+        <div class=container_class>
+            <span class=indicator_class></span>
             <span class="status-text">{status_text}</span>
         </div>
     }

--- a/crates/herald-web/src/ws.rs
+++ b/crates/herald-web/src/ws.rs
@@ -14,6 +14,8 @@ pub struct WebSocketState {
     pub previous_grid: Vec<Vec<RwSignal<CellContent>>>,
     /// Whether we're currently connected
     pub connected: RwSignal<bool>,
+    /// Whether we've received at least one board update
+    pub has_received_update: RwSignal<bool>,
     /// Trigger signal that increments on each board update (used to start animations)
     pub update_counter: RwSignal<u64>,
 }
@@ -48,12 +50,14 @@ pub fn use_websocket() -> WebSocketState {
         .collect();
 
     let connected = RwSignal::new(false);
+    let has_received_update = RwSignal::new(false);
     let update_counter = RwSignal::new(0u64);
 
     let state = WebSocketState {
         grid,
         previous_grid,
         connected,
+        has_received_update,
         update_counter,
     };
 
@@ -155,6 +159,11 @@ fn apply_board_update(board_state: &BoardState, state: &WebSocketState) {
             let new_cell = board_state.grid.0[row][col];
             state.grid[row][col].set(new_cell);
         }
+    }
+
+    // Mark that we've received at least one update
+    if !state.has_received_update.get_untracked() {
+        state.has_received_update.set(true);
     }
 
     // Increment update counter to trigger animations

--- a/scripts/build-web.ps1
+++ b/scripts/build-web.ps1
@@ -1,0 +1,44 @@
+#!/usr/bin/env pwsh
+# Build herald-web with Trunk and copy output to web-dist for serving.
+param(
+    [switch]$Release
+)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+$WebCrate = Join-Path $ProjectRoot "crates\herald-web"
+$DistDir = Join-Path $ProjectRoot "web-dist"
+
+if (-not (Test-Path (Join-Path $WebCrate "Cargo.toml"))) {
+    Write-Error "herald-web crate not found at $WebCrate"
+    exit 1
+}
+
+Write-Host "Building herald-web..." -ForegroundColor Cyan
+
+Push-Location $WebCrate
+try {
+    if ($Release) {
+        trunk build --release
+    } else {
+        trunk build
+    }
+} finally {
+    Pop-Location
+}
+
+# Copy Trunk dist output to web-dist
+$TrunkDist = Join-Path $WebCrate "dist"
+if (-not (Test-Path $TrunkDist)) {
+    Write-Error "Trunk build output not found at $TrunkDist"
+    exit 1
+}
+
+if (Test-Path $DistDir) {
+    Remove-Item -Recurse -Force $DistDir
+}
+Copy-Item -Recurse $TrunkDist $DistDir
+
+Write-Host "Web assets copied to $DistDir" -ForegroundColor Green
+Get-ChildItem $DistDir | Format-Table Name, Length


### PR DESCRIPTION
## Description

Enhance the web viewer with responsive scaling, proper loading/reconnection UX, and serve the compiled web assets directly from the Herald server.

### What's included

- **Responsive scaling (#45)** — Tile sizes now use viewport-based clamp() calculations so the 6×22 board always fits the screen without scrolling, from 375px mobile to 1440px+ desktop. Font sizes scale proportionally. Removed the previous horizontal scroll on mobile.
- **Loading state (#46)** — A gradient shimmer sweeps across all tiles while the WebSocket connection is being established, with a "Connecting..." indicator. When the first BoardUpdate arrives, all 132 tiles animate in simultaneously with the cascade stagger effect.
- **Reconnection indicator (#47)** — A fixed-position pill in the bottom-right corner shows connection state: green dot (auto-hides after 3s), yellow while connecting, red with "Reconnecting..." text when disconnected. The board retains its last known state during reconnection.
- **Static asset serving (#48)** — herald-server now serves compiled web assets via ServeDir fallback. Configurable with HERALD_WEB_DIR env var (defaults to ./web-dist if it exists). API and WebSocket routes take precedence. Includes uild-web.ps1 script to compile with Trunk and copy output.

## Related Issues

Closes #45, closes #46, closes #47, closes #48

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)