### PR TITLE
fix: countdown animation, Trunk proxy config, and web viewer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,25 @@
+# Build artifacts
 /target
+dist/
+web-dist/
+
+# SQLite databases
 *.db
 *.db-wal
 *.db-shm
 herald_test_*
-web-dist/
+
+# Environment & secrets
+.env
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Editor swap files
+*.swp
+*.swo
+*~
+
+# Trunk cache
+.trunk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Web viewer development proxy configuration in `Trunk.toml` (auto-proxies `/api` and `/ws` to the server)
+- Web viewer section in README with setup instructions for both production and development modes
+
+### Changed
+
+- Countdown animations in `herald watch` now use instant card-flip instead of cycling through intermediate characters, preventing animation overlap with 1-second countdown ticks
+
+### Fixed
+
+- Trunk dev server proxy error (`UnsupportedUrlScheme`) when connecting to the WebSocket backend
+
 ## [0.5.0] - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herald-cli"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "clap",
  "crossterm",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "herald-common"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "serde",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "herald-server"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "axum",
  "chrono",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "herald-web"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/herald-common", "crates/herald-server", "crates/herald-cli", 
 default-members = ["crates/herald-common", "crates/herald-server", "crates/herald-cli"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/kafkade/herald"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Herald is an open-source, split-flap / Vestaboard-style digital message board an
 - **Countdown timers** mixed into the rotation with real-time ticking
 - **Real-time WebSocket push** to all connected viewers
 - **Terminal viewer** — split-flap flip animations with left-to-right cascade stagger
+- **Web viewer** — Leptos + WebAssembly with 3D CSS flip animations, responsive scaling, and real-time WebSocket connection
 - **ANSI 256-color support** — vibrant color tiles with automatic fallback for basic terminals
 - **Animation speed control** — `fast`, `normal`, `slow`, or `off`
 - **Simple auth** — single admin with bearer-token authentication
@@ -27,7 +28,6 @@ Herald is an open-source, split-flap / Vestaboard-style digital message board an
 
 ### Roadmap (not yet implemented)
 
-- Browser viewer (Leptos + WebAssembly with 3D CSS flip animations)
 - Admin web panel and CLI admin subcommands
 - Docker packaging and deployment tooling
 - Sound effects, themes, scheduling, rate limiting
@@ -127,6 +127,33 @@ $env:HERALD_ADMIN_TOKEN = "your-token-here"
 .\scripts\set-rotation-interval.ps1 -Seconds 15
 ```
 
+### 5. Open the web viewer
+
+**Option A — Served from the server (production-style):**
+
+```powershell
+# Build the web assets (requires Trunk: cargo install trunk)
+.\scripts\build-web.ps1
+
+# Restart the server — it auto-detects web-dist/
+cargo run -p herald-server
+```
+
+Open `http://localhost:3000` in your browser. The server serves both the API and the web viewer.
+
+**Option B — Development with hot-reload:**
+
+```powershell
+# Terminal 1: start the server
+cargo run -p herald-server
+
+# Terminal 2: start the Trunk dev server
+cd crates\herald-web
+trunk serve
+```
+
+Open `http://localhost:8080` — Trunk serves the web viewer with live-reload and proxies API/WebSocket requests to the server.
+
 ### Using curl instead
 
 ```bash
@@ -166,6 +193,7 @@ All scripts live in `scripts/` and auto-detect `$env:HERALD_ADMIN_TOKEN`. Pass `
 | `remove-message.ps1` | Remove by `-Id`, `-All`, or list messages (no args) |
 | `list-queue.ps1` | Show all messages and countdowns in the rotation |
 | `set-rotation-interval.ps1` | Set rotation speed in `-Seconds` |
+| `build-web.ps1` | Build `herald-web` with Trunk and copy output to `web-dist/` |
 
 ---
 
@@ -176,8 +204,9 @@ Herald is structured as a Cargo workspace:
 ```
 crates/
   herald-common/    — Shared types (Grid, CellContent, Message, Countdown, etc.)
-  herald-server/    — Axum REST API + WebSocket + SQLite persistence
+  herald-server/    — Axum REST API + WebSocket + SQLite persistence + static file serving
   herald-cli/       — Terminal viewer (ratatui TUI) with split-flap animation
+  herald-web/       — Browser viewer (Leptos + Wasm) with 3D CSS flip animations
 ```
 
 ```
@@ -192,13 +221,14 @@ crates/
          │                             │
 ┌────────▼─────────┐        ┌─────────▼─────────┐
 │   herald-cli     │        │   herald-web      │
-│  (ratatui TUI)   │        │   (future)        │
-└────────┬─────────┘        └───────────────────┘
-         │
-┌────────▼─────────┐
-│  herald-common   │
-│  (shared types)  │
-└──────────────────┘
+│  (ratatui TUI)   │        │  (Leptos + Wasm)  │
+└────────┬─────────┘        └─────────┬─────────┘
+         │                            │
+         └────────────┬───────────────┘
+              ┌───────▼───────┐
+              │ herald-common │
+              │ (shared types)│
+              └───────────────┘
 ```
 
 **Data flow:** HTTP request → Axum handler → SQLite → JSON response. Board state broadcast via WebSocket to all connected viewers on every mutation.
@@ -266,19 +296,39 @@ Zero behaviors: `show_zero`, `remove`, `pause`, `show_message`.
 | `HERALD_DB_PATH` | `herald.db` | SQLite database file path |
 | `HERALD_PORT` | `3000` | Server listen port |
 | `HERALD_LOG_LEVEL` | `info` | Log level (trace, debug, info, warn, error) |
+| `HERALD_WEB_DIR` | `./web-dist` | Directory for compiled web viewer assets (auto-detected) |
 
 ---
 
 ## 🧪 Development
 
 ```bash
-cargo build                       # Debug build
+cargo build                       # Debug build (server + CLI)
 cargo test                        # Run all tests (~90 tests)
 cargo clippy                      # Lint
 cargo fmt                         # Format
 cargo run -p herald-server        # Start the server
 cargo run -p herald-cli -- watch  # Start the terminal viewer
 ```
+
+### Web viewer development
+
+```bash
+# Prerequisites (one-time)
+rustup target add wasm32-unknown-unknown
+cargo install trunk
+
+# Check the web crate compiles
+cargo check -p herald-web --target wasm32-unknown-unknown
+
+# Build for production
+.\scripts\build-web.ps1 -Release
+
+# Dev server with hot-reload (in crates/herald-web/)
+trunk serve
+```
+
+Note: `herald-web` is excluded from the default workspace members since it requires the `wasm32-unknown-unknown` target. Use `-p herald-web --target wasm32-unknown-unknown` when checking or building it directly.
 
 ---
 

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -165,11 +165,12 @@ async fn run_tui(
                         anim.sample_into(Instant::now(), &mut current_display);
                     }
 
-                    let new_anim = BoardAnimation::new(
+                    let new_anim = BoardAnimation::with_options(
                         &current_display,
                         &new_board,
                         speed.step_duration(),
                         speed.stagger_per_column(),
+                        queue_rx.borrow().is_countdown_active,
                     );
 
                     if new_anim.has_changes() {

--- a/crates/herald-cli/src/ui/animation.rs
+++ b/crates/herald-cli/src/ui/animation.rs
@@ -176,11 +176,27 @@ impl BoardAnimation {
     /// - `to`: the new target `BoardState`
     /// - `step_duration`: time per character step (~50ms)
     /// - `stagger_per_column`: cascade delay between columns (~20ms)
+    #[allow(dead_code)] // Used by tests; production code calls with_options directly
     pub fn new(
         from: &DisplayGrid,
         to: &BoardState,
         step_duration: Duration,
         stagger_per_column: Duration,
+    ) -> Self {
+        Self::with_options(from, to, step_duration, stagger_per_column, false)
+    }
+
+    /// Create a board animation with a direct "card flip" mode.
+    ///
+    /// When `instant_flip` is true, changed cells snap directly to their target
+    /// in a single step instead of cycling through intermediate characters.
+    /// Used for countdown ticks where the seconds change every second.
+    pub fn with_options(
+        from: &DisplayGrid,
+        to: &BoardState,
+        step_duration: Duration,
+        stagger_per_column: Duration,
+        instant_flip: bool,
     ) -> Self {
         let now = Instant::now();
         let mut cells = Vec::with_capacity(BOARD_ROWS);
@@ -264,12 +280,17 @@ impl BoardAnimation {
                             target: *to_content,
                         })
                     }
-                    // Non-color → Non-color: standard char cycling
+                    // Non-color → Non-color: standard char cycling (or instant flip)
                     (None, None) => {
                         let from_ch = display_char(from_state);
                         let to_ch = target_char(to_content);
                         if from_ch != to_ch {
-                            let steps = cycling_steps(from_ch, to_ch);
+                            let steps = if instant_flip {
+                                // Card flip: snap directly to target in one step
+                                vec![to_ch]
+                            } else {
+                                cycling_steps(from_ch, to_ch)
+                            };
                             Some(CellAnimation {
                                 kind: AnimationKind::Char {
                                     steps,

--- a/crates/herald-web/Trunk.toml
+++ b/crates/herald-web/Trunk.toml
@@ -4,3 +4,13 @@ dist = "dist"
 
 [watch]
 watch = ["src", "index.html"]
+
+[serve]
+port = 8080
+
+[[proxy]]
+backend = "http://localhost:3000/api"
+
+[[proxy]]
+backend = "ws://localhost:3000/ws"
+ws = true


### PR DESCRIPTION
## Description

Post-release fixes for v0.5.0: fix the CLI countdown animation, correct the web viewer proxy configuration, update README with web viewer docs, and clean up .gitignore.

### What's included

- **Countdown instant-flip animation** — Countdown ticks in herald watch now use a direct card-flip (1 step) instead of cycling through the entire character set (~56 steps). Previously, a seconds digit change like 5 → 4 would cycle forward through all intermediate characters, taking ~2.8s — longer than the 1-second countdown tick interval.
- **Trunk proxy fix** — The WebSocket proxy in Trunk.toml now uses ws:// protocol instead of http://, fixing an UnsupportedUrlScheme error when running the dev server.
- **Trunk proxy config** — Proxy settings for /api and /ws are now configured in Trunk.toml so 	runk serve works without any CLI flags.
- **README web viewer docs** — Added "Open the web viewer" section with production and development setup instructions, updated architecture diagram, added HERALD_WEB_DIR to env var table, and added web development commands.
- **.gitignore cleanup** — Added entries for .env, .DS_Store, Thumbs.db, editor swap files, dist/, and .trunk/ cache.

## Related Issues

Follow-up fixes after v0.5.0 release.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)