### PR TITLE
feat(cli): add push and countdown subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web viewer development proxy configuration in `Trunk.toml` (auto-proxies `/api` and `/ws` to the server)
 - Web viewer section in README with setup instructions for both production and development modes
 - `requestAnimationFrame` batching for WebSocket board updates — coalesces rapid messages into a single paint frame for smoother 60fps animations
+- `herald push "TEXT"` command to post messages to the board via REST API, with `--align`, `--expires`, `--server`, and `--token` flags
+- `herald countdown create`, `list`, and `delete` subcommands for managing countdowns via REST API, with formatted table output showing remaining time
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,13 +1099,16 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "herald-cli"
 version = "0.5.2"
 dependencies = [
+ "chrono",
  "clap",
  "crossterm",
  "futures-util",
  "herald-common",
  "ratatui",
+ "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,14 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono", "uuid
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
+# HTTP client
+reqwest = { version = "0.12", features = ["json"] }
+
 # Error handling
 thiserror = "2"
 
 # CLI
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 ratatui = "0.29"
 crossterm = "0.28"
 

--- a/crates/herald-cli/Cargo.toml
+++ b/crates/herald-cli/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 futures-util = { workspace = true }
 tracing = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/herald-cli/src/api_client.rs
+++ b/crates/herald-cli/src/api_client.rs
@@ -1,0 +1,132 @@
+use herald_common::ErrorResponse;
+use reqwest::StatusCode;
+
+/// User-friendly errors for API operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("Connection refused — is the Herald server running at {0}?")]
+    ConnectionRefused(String),
+    #[error("Authentication failed — check your --token value")]
+    Unauthorized,
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+    #[error("Server error: {0}")]
+    ServerError(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// HTTP client for the Herald REST API.
+pub struct ApiClient {
+    client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl ApiClient {
+    pub fn new(base_url: &str, token: &str) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token: token.to_string(),
+        }
+    }
+
+    /// Send a POST request with a JSON body and return the deserialized response.
+    pub async fn post<Req, Res>(&self, path: &str, body: &Req) -> Result<Res, ApiError>
+    where
+        Req: serde::Serialize,
+        Res: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| classify_request_error(e, &self.base_url))?;
+
+        handle_response(response).await
+    }
+
+    /// Send a GET request and return the deserialized response.
+    pub async fn get<Res>(&self, path: &str) -> Result<Res, ApiError>
+    where
+        Res: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| classify_request_error(e, &self.base_url))?;
+
+        handle_response(response).await
+    }
+
+    /// Send a DELETE request. Returns Ok(()) on 204 No Content.
+    pub async fn delete(&self, path: &str) -> Result<(), ApiError> {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .delete(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| classify_request_error(e, &self.base_url))?;
+
+        let status = response.status();
+        if status == StatusCode::NO_CONTENT || status.is_success() {
+            return Ok(());
+        }
+
+        Err(classify_status_error(status, response).await)
+    }
+}
+
+/// Classify a reqwest transport error into a user-friendly ApiError.
+fn classify_request_error(err: reqwest::Error, base_url: &str) -> ApiError {
+    if err.is_connect() {
+        ApiError::ConnectionRefused(base_url.to_string())
+    } else {
+        ApiError::Other(err.to_string())
+    }
+}
+
+/// Extract the error body and classify by HTTP status code.
+async fn classify_status_error(status: StatusCode, response: reqwest::Response) -> ApiError {
+    let body_msg = response
+        .json::<ErrorResponse>()
+        .await
+        .map(|e| e.message)
+        .unwrap_or_else(|_| status.to_string());
+
+    match status {
+        StatusCode::UNAUTHORIZED => ApiError::Unauthorized,
+        StatusCode::NOT_FOUND => ApiError::NotFound(body_msg),
+        StatusCode::BAD_REQUEST => ApiError::BadRequest(body_msg),
+        s if s.is_server_error() => ApiError::ServerError(body_msg),
+        _ => ApiError::Other(format!("{status}: {body_msg}")),
+    }
+}
+
+/// Handle a successful HTTP response, deserializing the JSON body.
+async fn handle_response<Res: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<Res, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        response
+            .json::<Res>()
+            .await
+            .map_err(|e| ApiError::Other(format!("Failed to parse response: {e}")))
+    } else {
+        Err(classify_status_error(status, response).await)
+    }
+}

--- a/crates/herald-cli/src/commands/countdown.rs
+++ b/crates/herald-cli/src/commands/countdown.rs
@@ -1,0 +1,138 @@
+use crate::api_client::ApiClient;
+use chrono::{DateTime, Utc};
+use herald_common::{Countdown, CreateCountdownRequest, ListResponse, ZeroBehavior};
+
+pub async fn create(
+    server: String,
+    token: String,
+    label: String,
+    target: String,
+    zero_behavior: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let target: DateTime<Utc> = target.parse().map_err(|e| {
+        format!(
+            "invalid target timestamp '{target}': expected ISO-8601 format \
+             (e.g. 2025-12-31T00:00:00Z): {e}"
+        )
+    })?;
+
+    let zero_behavior = match zero_behavior.to_lowercase().as_str() {
+        "show_zero" => ZeroBehavior::ShowZero,
+        "remove" => ZeroBehavior::Remove,
+        "pause" => ZeroBehavior::Pause,
+        other => {
+            return Err(format!(
+                "invalid zero_behavior '{other}': expected 'show_zero', 'remove', or 'pause'"
+            )
+            .into());
+        }
+    };
+
+    let request = CreateCountdownRequest {
+        label: label.clone(),
+        target,
+        format_template: "{D} DAYS  {HH}:{MM}:{SS}".to_string(),
+        zero_behavior,
+        queue_position: None,
+    };
+
+    let client = ApiClient::new(&server, &token);
+    let countdown: Countdown = client.post("/api/countdowns", &request).await?;
+
+    println!("Created countdown {} — \"{label}\"", countdown.id);
+
+    Ok(())
+}
+
+pub async fn list(server: String, token: String) -> Result<(), Box<dyn std::error::Error>> {
+    let client = ApiClient::new(&server, &token);
+    let response: ListResponse<Countdown> = client.get("/api/countdowns").await?;
+
+    if response.items.is_empty() {
+        println!("No countdowns found");
+        return Ok(());
+    }
+
+    // Column widths
+    let id_w = 8;
+    let label_w = 20;
+    let target_w = 20;
+    let remaining_w = 16;
+
+    println!(
+        "{:<id_w$}  {:<label_w$}  {:<target_w$}  {:<remaining_w$}",
+        "ID", "LABEL", "TARGET", "REMAINING"
+    );
+    println!(
+        "{:<id_w$}  {:<label_w$}  {:<target_w$}  {:<remaining_w$}",
+        "—".repeat(id_w),
+        "—".repeat(label_w),
+        "—".repeat(target_w),
+        "—".repeat(remaining_w),
+    );
+
+    for countdown in &response.items {
+        let short_id = &countdown.id.to_string()[..8];
+        let target_str = countdown.target.format("%Y-%m-%d %H:%M UTC").to_string();
+        let remaining = format_remaining(&countdown.target);
+
+        let label_display = if countdown.label.len() > label_w {
+            format!("{}…", &countdown.label[..label_w - 1])
+        } else {
+            countdown.label.clone()
+        };
+
+        println!(
+            "{:<id_w$}  {:<label_w$}  {:<target_w$}  {:<remaining_w$}",
+            short_id, label_display, target_str, remaining
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn delete(
+    server: String,
+    token: String,
+    id: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate UUID format (8-4-4-4-12 hex digits)
+    let is_valid_uuid = id.len() == 36
+        && id.chars().enumerate().all(|(i, c)| match i {
+            8 | 13 | 18 | 23 => c == '-',
+            _ => c.is_ascii_hexdigit(),
+        });
+
+    if !is_valid_uuid {
+        return Err(format!(
+            "invalid countdown ID '{id}': expected a UUID \
+             (e.g. 550e8400-e29b-41d4-a716-446655440000)"
+        )
+        .into());
+    }
+
+    let client = ApiClient::new(&server, &token);
+    client.delete(&format!("/api/countdowns/{id}")).await?;
+
+    println!("Deleted countdown {id}");
+
+    Ok(())
+}
+
+fn format_remaining(target: &DateTime<Utc>) -> String {
+    let remaining = *target - Utc::now();
+    if remaining <= chrono::Duration::zero() {
+        "expired".to_string()
+    } else {
+        let days = remaining.num_days();
+        let hours = remaining.num_hours() % 24;
+        let minutes = remaining.num_minutes() % 60;
+        if days > 0 {
+            format!("{days}d {hours}h {minutes}m")
+        } else if hours > 0 {
+            format!("{hours}h {minutes}m")
+        } else {
+            format!("{minutes}m")
+        }
+    }
+}

--- a/crates/herald-cli/src/commands/mod.rs
+++ b/crates/herald-cli/src/commands/mod.rs
@@ -1,1 +1,3 @@
+pub mod countdown;
+pub mod push;
 pub mod watch;

--- a/crates/herald-cli/src/commands/push.rs
+++ b/crates/herald-cli/src/commands/push.rs
@@ -1,0 +1,47 @@
+use crate::api_client::ApiClient;
+use chrono::{DateTime, Utc};
+use herald_common::{CreateMessageRequest, HAlign, Message, VAlign};
+
+pub async fn run(
+    text: String,
+    server: String,
+    token: String,
+    align: String,
+    expires: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let h_align = match align.to_lowercase().as_str() {
+        "left" => HAlign::Left,
+        "center" => HAlign::Center,
+        "right" => HAlign::Right,
+        other => {
+            return Err(format!(
+                "invalid alignment '{other}': expected 'left', 'center', or 'right'"
+            )
+            .into());
+        }
+    };
+
+    let expires_at = expires
+        .map(|s| {
+            s.parse::<DateTime<Utc>>().map_err(|e| {
+                format!("invalid expires timestamp '{s}': expected ISO-8601 format (e.g. 2025-12-31T23:59:59Z): {e}")
+            })
+        })
+        .transpose()?;
+
+    let request = CreateMessageRequest {
+        text: Some(text),
+        grid: None,
+        h_align,
+        v_align: VAlign::default(),
+        queue_position: None,
+        expires_at,
+    };
+
+    let client = ApiClient::new(&server, &token);
+    let message: Message = client.post("/api/messages", &request).await?;
+
+    println!("Created message {}", message.id);
+
+    Ok(())
+}

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -1,8 +1,9 @@
+mod api_client;
 mod commands;
 mod ui;
 mod ws_client;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use commands::watch::AnimationSpeed;
 
 #[derive(Parser)]
@@ -11,6 +12,17 @@ use commands::watch::AnimationSpeed;
 struct Cli {
     #[command(subcommand)]
     command: Command,
+}
+
+/// Shared API connection arguments for admin commands.
+#[derive(Args, Clone)]
+struct ApiArgs {
+    /// Herald server URL
+    #[arg(long, default_value = "http://localhost:3000")]
+    server: String,
+    /// Bearer token for authentication
+    #[arg(long, env = "HERALD_ADMIN_TOKEN")]
+    token: String,
 }
 
 #[derive(Subcommand)]
@@ -30,13 +42,57 @@ enum Command {
         animation_speed: AnimationSpeed,
     },
     /// Push a message to the board
-    Push,
+    Push {
+        /// Message text to display
+        text: String,
+        /// Text alignment: left, center, or right
+        #[arg(long, default_value = "center")]
+        align: String,
+        /// Expiry time in ISO-8601 format (e.g. "2025-12-31T23:59:59Z")
+        #[arg(long)]
+        expires: Option<String>,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
     /// Manage countdowns
-    Countdown,
+    Countdown {
+        #[command(subcommand)]
+        command: CountdownCommand,
+    },
     /// Manage the display queue
     Queue,
     /// View or update server configuration
     Config,
+}
+
+#[derive(Subcommand)]
+enum CountdownCommand {
+    /// Create a new countdown
+    Create {
+        /// Countdown label (e.g. "NEW YEAR")
+        #[arg(long)]
+        label: String,
+        /// Target time in ISO-8601 format (e.g. "2025-12-31T00:00:00Z")
+        #[arg(long)]
+        target: String,
+        /// Behavior when countdown reaches zero: show_zero, remove, or pause
+        #[arg(long, default_value = "show_zero")]
+        zero_behavior: String,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
+    /// List all countdowns
+    List {
+        #[command(flatten)]
+        api: ApiArgs,
+    },
+    /// Delete a countdown
+    Delete {
+        /// Countdown ID to delete
+        id: String,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
 }
 
 #[tokio::main]
@@ -53,14 +109,29 @@ async fn main() {
             eprintln!("serve is not yet implemented");
             Ok(())
         }
-        Command::Push => {
-            eprintln!("push is not yet implemented");
-            Ok(())
-        }
-        Command::Countdown => {
-            eprintln!("countdown is not yet implemented");
-            Ok(())
-        }
+        Command::Push {
+            text,
+            align,
+            expires,
+            api,
+        } => commands::push::run(text, api.server, api.token, align, expires).await,
+        Command::Countdown { command } => match command {
+            CountdownCommand::Create {
+                label,
+                target,
+                zero_behavior,
+                api,
+            } => {
+                commands::countdown::create(api.server, api.token, label, target, zero_behavior)
+                    .await
+            }
+            CountdownCommand::List { api } => {
+                commands::countdown::list(api.server, api.token).await
+            }
+            CountdownCommand::Delete { id, api } => {
+                commands::countdown::delete(api.server, api.token, id).await
+            }
+        },
         Command::Queue => {
             eprintln!("queue is not yet implemented");
             Ok(())

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -380,7 +380,7 @@ pub enum ClientMessage {
 
 /// Request body for POST /api/messages.
 /// Accepts either `text` (auto-rendered) or `grid` (raw 6×22), but not both.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateMessageRequest {
     pub text: Option<String>,
     pub grid: Option<Grid>,
@@ -405,7 +405,7 @@ pub struct UpdateMessageRequest {
 }
 
 /// Request body for POST /api/countdowns.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCountdownRequest {
     pub label: String,
     pub target: DateTime<Utc>,
@@ -446,7 +446,7 @@ pub struct UpdateConfigRequest {
 // ── Standard API response wrappers ────────────────────────────────
 
 /// Standard list response.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ListResponse<T: Serialize> {
     pub items: Vec<T>,
     pub total: usize,


### PR DESCRIPTION
## Description

Add `herald push` and `herald countdown` CLI subcommands for managing messages and countdowns via the REST API.

### What's included

- **`herald push "TEXT"`** — Posts a message to the board. Supports `--align` (left/center/right), `--expires` (ISO-8601), `--server`, and `--token` flags. Prints the created message ID on success.
- **`herald countdown create`** — Creates a countdown with `--label`, `--target` (ISO-8601), and optional `--zero-behavior` (show_zero/remove/pause).
- **`herald countdown list`** — Lists all countdowns in a formatted table showing short ID, label, target date, and human-readable remaining time (e.g. "3d 14h 22m" or "expired").
- **`herald countdown delete <ID>`** — Deletes a countdown by UUID.
- **Shared `ApiClient` module** — Reusable HTTP client wrapping reqwest with user-friendly error messages for connection refused, authentication failure, invalid input, and server errors.
- **Shared `ApiArgs`** — `--server` and `--token` flags (with `HERALD_ADMIN_TOKEN` env var support) flattened into all admin commands.

## Related Issues

Closes #50
Closes #51

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
