### PR TITLE
feat(cli): add queue, config subcommands and color markup parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `requestAnimationFrame` batching for WebSocket board updates — coalesces rapid messages into a single paint frame for smoother 60fps animations
 - `herald push "TEXT"` command to post messages to the board via REST API, with `--align`, `--expires`, `--server`, and `--token` flags
 - `herald countdown create`, `list`, and `delete` subcommands for managing countdowns via REST API, with formatted table output showing remaining time
+- `herald queue list` and `herald queue reorder` subcommands for viewing and reordering the display queue
+- `herald config get` and `herald config set` subcommands for viewing and updating server configuration
+- Color markup parser in `herald-common` supporting `{red}text{/red}` syntax for all 8 Vestaboard colors, with nested tag and shorthand `{}` close support
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/herald-cli/Cargo.toml
+++ b/crates/herald-cli/Cargo.toml
@@ -23,3 +23,4 @@ tracing = { workspace = true }
 reqwest = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/crates/herald-cli/src/api_client.rs
+++ b/crates/herald-cli/src/api_client.rs
@@ -70,6 +70,25 @@ impl ApiClient {
         handle_response(response).await
     }
 
+    /// Send a PUT request with a JSON body and return the deserialized response.
+    pub async fn put<Req, Res>(&self, path: &str, body: &Req) -> Result<Res, ApiError>
+    where
+        Req: serde::Serialize,
+        Res: serde::de::DeserializeOwned,
+    {
+        let url = format!("{}{path}", self.base_url);
+        let response = self
+            .client
+            .put(&url)
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| classify_request_error(e, &self.base_url))?;
+
+        handle_response(response).await
+    }
+
     /// Send a DELETE request. Returns Ok(()) on 204 No Content.
     pub async fn delete(&self, path: &str) -> Result<(), ApiError> {
         let url = format!("{}{path}", self.base_url);

--- a/crates/herald-cli/src/commands/config.rs
+++ b/crates/herald-cli/src/commands/config.rs
@@ -1,0 +1,123 @@
+use crate::api_client::ApiClient;
+use herald_common::UpdateConfigRequest;
+
+const KNOWN_KEYS: &[&str] = &[
+    "rotation_interval_seconds",
+    "countdown_refresh_seconds",
+    "default_h_align",
+    "default_v_align",
+    "default_color",
+    "countdown_zero_behavior",
+];
+
+fn config_description(key: &str) -> &'static str {
+    match key {
+        "rotation_interval_seconds" => "Seconds between queue item rotation",
+        "countdown_refresh_seconds" => "How often countdown displays refresh",
+        "default_h_align" => "Default horizontal alignment (left/center/right)",
+        "default_v_align" => "Default vertical alignment (top/middle)",
+        "default_color" => "Default tile color",
+        "countdown_zero_behavior" => "What happens when countdown reaches zero",
+        _ => "",
+    }
+}
+
+/// Get one or all configuration values.
+pub async fn get(
+    server: String,
+    token: String,
+    key: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = ApiClient::new(&server, &token);
+    let config: serde_json::Map<String, serde_json::Value> = client.get("/api/config").await?;
+
+    match key {
+        Some(k) => {
+            let value = config
+                .get(&k)
+                .ok_or_else(|| format!("Unknown config key: {k}"))?;
+            println!("{}", format_value(value));
+        }
+        None => {
+            // Determine column widths
+            let key_width = config.keys().map(|k| k.len()).max().unwrap_or(3).max(3);
+            let val_width = config
+                .values()
+                .map(|v| format_value(v).len())
+                .max()
+                .unwrap_or(5)
+                .max(5);
+
+            println!(
+                "{:<key_width$}    {:<val_width$}    DESCRIPTION",
+                "KEY", "VALUE"
+            );
+            let key_sep = "─".repeat(key_width);
+            let val_sep = "─".repeat(val_width);
+            println!("{key_sep}    {val_sep}    ───────────",);
+
+            for (k, v) in &config {
+                println!(
+                    "{:<key_width$}    {:<val_width$}    {}",
+                    k,
+                    format_value(v),
+                    config_description(k)
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Set a configuration value.
+pub async fn set(
+    server: String,
+    token: String,
+    key: String,
+    value: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !KNOWN_KEYS.contains(&key.as_str()) {
+        eprintln!("Warning: '{key}' is not a known config key");
+    }
+
+    let client = ApiClient::new(&server, &token);
+
+    // Read current value
+    let current: serde_json::Map<String, serde_json::Value> = client.get("/api/config").await?;
+    let old_value = current
+        .get(&key)
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    // Parse value: try number first, fall back to string
+    let json_value: serde_json::Value = if let Ok(n) = value.parse::<i64>() {
+        serde_json::Value::Number(n.into())
+    } else if let Ok(n) = value.parse::<f64>() {
+        serde_json::Number::from_f64(n)
+            .map(serde_json::Value::Number)
+            .unwrap_or_else(|| serde_json::Value::String(value.clone()))
+    } else {
+        serde_json::Value::String(value.clone())
+    };
+
+    let mut values = serde_json::Map::new();
+    values.insert(key.clone(), json_value);
+
+    let _updated: serde_json::Map<String, serde_json::Value> = client
+        .put("/api/config", &UpdateConfigRequest { values })
+        .await?;
+
+    println!("{key}: {} → {}", format_value(&old_value), value);
+
+    Ok(())
+}
+
+/// Format a JSON value for display.
+fn format_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}

--- a/crates/herald-cli/src/commands/mod.rs
+++ b/crates/herald-cli/src/commands/mod.rs
@@ -1,3 +1,5 @@
+pub mod config;
 pub mod countdown;
 pub mod push;
+pub mod queue;
 pub mod watch;

--- a/crates/herald-cli/src/commands/queue.rs
+++ b/crates/herald-cli/src/commands/queue.rs
@@ -1,0 +1,87 @@
+use crate::api_client::ApiClient;
+use herald_common::{QueueItemKind, QueueListResponse, ReorderQueueRequest};
+use uuid::Uuid;
+
+pub async fn list(server: String, token: String) -> Result<(), Box<dyn std::error::Error>> {
+    let client = ApiClient::new(&server, &token);
+    let response: QueueListResponse = client.get("/api/queue").await?;
+
+    if response.items.is_empty() {
+        println!("Queue is empty");
+        return Ok(());
+    }
+
+    let pos_w = 4;
+    let type_w = 10;
+    let label_w = 20;
+    let expires_w = 20;
+
+    println!(
+        "{:<pos_w$}  {:<type_w$}  {:<label_w$}  {:<expires_w$}",
+        "#", "TYPE", "LABEL", "EXPIRES"
+    );
+    println!(
+        "{:<pos_w$}  {:<type_w$}  {:<label_w$}  {:<expires_w$}",
+        "—".repeat(pos_w),
+        "—".repeat(type_w),
+        "—".repeat(label_w),
+        "—".repeat(expires_w),
+    );
+
+    for (i, item) in response.items.iter().enumerate() {
+        let prefix = if i as i64 == response.current_index {
+            "▶"
+        } else {
+            " "
+        };
+
+        let kind_str = match item.kind {
+            QueueItemKind::Message => "message",
+            QueueItemKind::Countdown => "countdown",
+        };
+
+        let expires_str = item
+            .expires_at
+            .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+            .unwrap_or_else(|| "—".to_string());
+
+        let label_display = if item.label.len() > label_w {
+            format!("{}…", &item.label[..label_w - 1])
+        } else {
+            item.label.clone()
+        };
+
+        println!(
+            "{prefix} {:<pos_w$}  {:<type_w$}  {:<label_w$}  {:<expires_w$}",
+            item.queue_position, kind_str, label_display, expires_str
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn reorder(
+    server: String,
+    token: String,
+    ids: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let order: Vec<Uuid> = ids
+        .iter()
+        .map(|s| {
+            s.parse::<Uuid>().map_err(|_| {
+                format!(
+                    "invalid UUID '{s}': expected format like 550e8400-e29b-41d4-a716-446655440000"
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let request = ReorderQueueRequest { order };
+
+    let client = ApiClient::new(&server, &token);
+    let _: QueueListResponse = client.put("/api/queue/reorder", &request).await?;
+
+    println!("Queue reordered");
+
+    Ok(())
+}

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -60,9 +60,51 @@ enum Command {
         command: CountdownCommand,
     },
     /// Manage the display queue
-    Queue,
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
     /// View or update server configuration
-    Config,
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum QueueCommand {
+    /// List the display queue
+    List {
+        #[command(flatten)]
+        api: ApiArgs,
+    },
+    /// Reorder the display queue
+    Reorder {
+        /// Queue item IDs in desired order
+        ids: Vec<String>,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Get configuration values
+    Get {
+        /// Specific key to look up (shows all if omitted)
+        key: Option<String>,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
+    /// Set a configuration value
+    Set {
+        /// Configuration key
+        key: String,
+        /// New value
+        value: String,
+        #[command(flatten)]
+        api: ApiArgs,
+    },
 }
 
 #[derive(Subcommand)]
@@ -132,14 +174,20 @@ async fn main() {
                 commands::countdown::delete(api.server, api.token, id).await
             }
         },
-        Command::Queue => {
-            eprintln!("queue is not yet implemented");
-            Ok(())
-        }
-        Command::Config => {
-            eprintln!("config is not yet implemented");
-            Ok(())
-        }
+        Command::Queue { command } => match command {
+            QueueCommand::List { api } => commands::queue::list(api.server, api.token).await,
+            QueueCommand::Reorder { ids, api } => {
+                commands::queue::reorder(api.server, api.token, ids).await
+            }
+        },
+        Command::Config { command } => match command {
+            ConfigCommand::Get { key, api } => {
+                commands::config::get(api.server, api.token, key).await
+            }
+            ConfigCommand::Set { key, value, api } => {
+                commands::config::set(api.server, api.token, key, value).await
+            }
+        },
     };
 
     if let Err(e) = result {

--- a/crates/herald-common/src/color_markup.rs
+++ b/crates/herald-common/src/color_markup.rs
@@ -1,0 +1,336 @@
+use crate::types::Color;
+
+/// A character with an optional color from markup parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColoredChar {
+    pub ch: char,
+    pub color: Option<Color>,
+}
+
+/// Resolve a tag name (case-insensitive) to a `Color`.
+fn parse_color_tag(tag: &str) -> Option<Color> {
+    match tag.to_lowercase().as_str() {
+        "red" => Some(Color::Red),
+        "orange" => Some(Color::Orange),
+        "yellow" => Some(Color::Yellow),
+        "green" => Some(Color::Green),
+        "blue" => Some(Color::Blue),
+        "violet" => Some(Color::Violet),
+        "white" => Some(Color::White),
+        "black" => Some(Color::Black),
+        _ => None,
+    }
+}
+
+/// Parse text with color markup tags.
+///
+/// Supported syntax:
+/// - `{red}text{/red}` — applies red color to "text"
+/// - `{red}text{}` — shorthand: `{}` closes the current color
+/// - Nested tags: innermost color wins (stack-based)
+/// - Invalid/unrecognized tags are rendered literally including braces
+///
+/// Returns a `Vec<ColoredChar>` where each char may have an associated color.
+pub fn parse_color_markup(input: &str) -> Vec<ColoredChar> {
+    let mut result = Vec::new();
+    let mut color_stack: Vec<Color> = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        if chars[i] == '{' {
+            // Try to find the closing '}'
+            if let Some(close) = chars[i + 1..].iter().position(|&c| c == '}') {
+                let close = i + 1 + close;
+                let tag_content: String = chars[i + 1..close].iter().collect();
+
+                if tag_content.is_empty() {
+                    // `{}` — shorthand close: pop top of stack
+                    color_stack.pop();
+                    i = close + 1;
+                } else if let Some(stripped) = tag_content.strip_prefix('/') {
+                    // Closing tag like `{/red}`
+                    if let Some(color) = parse_color_tag(stripped) {
+                        // Pop the matching color from the stack (search from top)
+                        if let Some(pos) = color_stack.iter().rposition(|c| *c == color) {
+                            color_stack.remove(pos);
+                        } else {
+                            // No matching open tag — render literally
+                            emit_literal(&chars[i..=close], &color_stack, &mut result);
+                        }
+                    } else {
+                        // Invalid closing tag — render literally
+                        emit_literal(&chars[i..=close], &color_stack, &mut result);
+                    }
+                    i = close + 1;
+                } else if let Some(color) = parse_color_tag(&tag_content) {
+                    // Valid opening tag
+                    color_stack.push(color);
+                    i = close + 1;
+                } else {
+                    // Invalid tag name — render literally
+                    emit_literal(&chars[i..=close], &color_stack, &mut result);
+                    i = close + 1;
+                }
+            } else {
+                // No closing '}' found — emit '{' literally, rest will follow
+                result.push(ColoredChar {
+                    ch: '{',
+                    color: color_stack.last().copied(),
+                });
+                i += 1;
+            }
+        } else {
+            result.push(ColoredChar {
+                ch: chars[i],
+                color: color_stack.last().copied(),
+            });
+            i += 1;
+        }
+    }
+
+    result
+}
+
+/// Emit a slice of characters literally with the current color.
+fn emit_literal(chars: &[char], color_stack: &[Color], result: &mut Vec<ColoredChar>) {
+    let color = color_stack.last().copied();
+    for &ch in chars {
+        result.push(ColoredChar { ch, color });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chars_text(chars: &[ColoredChar]) -> String {
+        chars.iter().map(|c| c.ch).collect()
+    }
+
+    #[test]
+    fn plain_text_no_markup() {
+        let result = parse_color_markup("HELLO");
+        assert_eq!(result.len(), 5);
+        assert_eq!(chars_text(&result), "HELLO");
+        assert!(result.iter().all(|c| c.color.is_none()));
+    }
+
+    #[test]
+    fn single_color_tag() {
+        let result = parse_color_markup("{red}HI{/red}");
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'H',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'I',
+                color: Some(Color::Red)
+            }
+        );
+    }
+
+    #[test]
+    fn shorthand_close() {
+        let result = parse_color_markup("{red}HI{}");
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'H',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'I',
+                color: Some(Color::Red)
+            }
+        );
+    }
+
+    #[test]
+    fn mixed_colored_and_plain() {
+        let result = parse_color_markup("A{blue}BC{}D");
+        assert_eq!(result.len(), 4);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'A',
+                color: None
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'B',
+                color: Some(Color::Blue)
+            }
+        );
+        assert_eq!(
+            result[2],
+            ColoredChar {
+                ch: 'C',
+                color: Some(Color::Blue)
+            }
+        );
+        assert_eq!(
+            result[3],
+            ColoredChar {
+                ch: 'D',
+                color: None
+            }
+        );
+    }
+
+    #[test]
+    fn nested_colors() {
+        let result = parse_color_markup("{red}A{blue}B{/blue}C{/red}");
+        assert_eq!(result.len(), 3);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'A',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'B',
+                color: Some(Color::Blue)
+            }
+        );
+        assert_eq!(
+            result[2],
+            ColoredChar {
+                ch: 'C',
+                color: Some(Color::Red)
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_tag_rendered_literally() {
+        let result = parse_color_markup("{invalid}HI");
+        assert_eq!(chars_text(&result), "{invalid}HI");
+        assert!(result.iter().all(|c| c.color.is_none()));
+    }
+
+    #[test]
+    fn empty_input() {
+        let result = parse_color_markup("");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn unclosed_brace() {
+        let result = parse_color_markup("{red");
+        assert_eq!(chars_text(&result), "{red");
+        assert!(result.iter().all(|c| c.color.is_none()));
+    }
+
+    #[test]
+    fn close_without_open() {
+        let result = parse_color_markup("{/red}HI");
+        // No matching open → rendered literally, then HI
+        assert_eq!(chars_text(&result), "{/red}HI");
+        assert!(result.iter().all(|c| c.color.is_none()));
+    }
+
+    #[test]
+    fn all_colors_supported() {
+        let colors = [
+            ("red", Color::Red),
+            ("orange", Color::Orange),
+            ("yellow", Color::Yellow),
+            ("green", Color::Green),
+            ("blue", Color::Blue),
+            ("violet", Color::Violet),
+            ("white", Color::White),
+            ("black", Color::Black),
+        ];
+        for (name, expected) in colors {
+            let input = format!("{{{name}}}X{{/{name}}}");
+            let result = parse_color_markup(&input);
+            assert_eq!(result.len(), 1, "failed for {name}");
+            assert_eq!(result[0].color, Some(expected), "wrong color for {name}");
+            assert_eq!(result[0].ch, 'X');
+        }
+    }
+
+    #[test]
+    fn case_insensitive_tags() {
+        let result = parse_color_markup("{RED}HI{/RED}");
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'H',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'I',
+                color: Some(Color::Red)
+            }
+        );
+    }
+
+    #[test]
+    fn adjacent_tags() {
+        let result = parse_color_markup("{red}A{/red}{blue}B{/blue}");
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'A',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: 'B',
+                color: Some(Color::Blue)
+            }
+        );
+    }
+
+    #[test]
+    fn color_with_spaces() {
+        let result = parse_color_markup("{red}A B{/red}");
+        assert_eq!(result.len(), 3);
+        assert_eq!(
+            result[0],
+            ColoredChar {
+                ch: 'A',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[1],
+            ColoredChar {
+                ch: ' ',
+                color: Some(Color::Red)
+            }
+        );
+        assert_eq!(
+            result[2],
+            ColoredChar {
+                ch: 'B',
+                color: Some(Color::Red)
+            }
+        );
+    }
+}

--- a/crates/herald-common/src/lib.rs
+++ b/crates/herald-common/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod color_markup;
 pub mod countdown;
 pub mod types;
 
+pub use color_markup::*;
 pub use countdown::render_countdown_grid;
 pub use types::*;
 

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -431,13 +431,13 @@ pub struct UpdateCountdownRequest {
 }
 
 /// Request body for PUT /api/queue/reorder.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ReorderQueueRequest {
     pub order: Vec<Uuid>,
 }
 
 /// Request body for PUT /api/config.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateConfigRequest {
     #[serde(flatten)]
     pub values: serde_json::Map<String, serde_json::Value>,
@@ -453,7 +453,7 @@ pub struct ListResponse<T: Serialize> {
 }
 
 /// Queue list response with rotation info.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct QueueListResponse {
     pub items: Vec<QueueItem>,
     pub total: usize,


### PR DESCRIPTION
## Description

Add the remaining CLI admin subcommands (`queue`, `config`) and a color markup parser for inline color tags in message text.

### What's included

- **`herald queue list`** — Displays the current display queue as a formatted table (position, type, label, expiry), highlighting the currently displayed item with `▶`.
- **`herald queue reorder <id1> <id2> ...`** — Reorders the display queue by providing UUIDs in the desired order.
- **`herald config get [key]`** — Shows all server config as a key-value table with descriptions, or a specific key's value.
- **`herald config set <key> <value>`** — Updates a config value, displaying `key: old → new`. Warns on unrecognized keys.
- **Color markup parser** — `parse_color_markup()` in `herald-common` parses `{red}text{/red}` (and shorthand `{red}text{}`) syntax for all 8 Vestaboard colors. Supports nested tags (innermost wins) and renders invalid tags literally. Includes 13 unit tests.
- **`ApiClient::put()`** — Added PUT method to the shared API client for queue reorder and config set operations.

## Related Issues

Closes #52
Closes #53
Closes #54

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [x] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
