### PR TITLE
feat: add CLI preview, web admin panel with composer, countdown and queue managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `herald queue list` and `herald queue reorder` subcommands for viewing and reordering the display queue
 - `herald config get` and `herald config set` subcommands for viewing and updating server configuration
 - Color markup parser in `herald-common` supporting `{red}text{/red}` syntax for all 8 Vestaboard colors, with nested tag and shorthand `{}` close support
+- `--preview` flag for `herald push` that renders a 6×22 ASCII grid preview in the terminal before pushing, with interactive Y/n confirmation
+- Web admin panel at `/admin` with bearer token authentication, localStorage persistence, and automatic re-login on 401 responses
+- Web message composer in the admin panel with live 6×22 grid preview, alignment selector, optional expiry picker, and push-to-server functionality
+- Web countdown manager in the admin panel with create form, live remaining-time display, and delete with confirmation
+- Web queue manager in the admin panel with drag-to-reorder, current item highlighting, and auto-refresh
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
 name = "herald-web"
 version = "0.5.2"
 dependencies = [
+ "chrono",
  "console_error_panic_hook",
  "console_log",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ gloo-net = { version = "0.6", features = ["websocket"] }
 gloo-timers = { version = "0.3", features = ["futures"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Window", "Location"] }
+web-sys = { version = "0.3", features = ["Window", "Location", "Event", "EventTarget", "HtmlInputElement", "HtmlTextAreaElement", "HtmlSelectElement", "Storage", "Headers", "RequestInit", "RequestMode", "Request", "Response", "DragEvent", "DataTransfer", "HtmlElement"] }
 js-sys = "0.3"
 log = "0.4"
 console_log = "1"

--- a/crates/herald-cli/src/commands/push.rs
+++ b/crates/herald-cli/src/commands/push.rs
@@ -1,6 +1,9 @@
 use crate::api_client::ApiClient;
 use chrono::{DateTime, Utc};
-use herald_common::{CreateMessageRequest, HAlign, Message, VAlign};
+use herald_common::{
+    BOARD_COLS, BOARD_ROWS, CellContent, Color, CreateMessageRequest, Grid, HAlign, Message, VAlign,
+};
+use std::io::{self, BufRead, IsTerminal, Write};
 
 pub async fn run(
     text: String,
@@ -8,6 +11,7 @@ pub async fn run(
     token: String,
     align: String,
     expires: Option<String>,
+    preview: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let h_align = match align.to_lowercase().as_str() {
         "left" => HAlign::Left,
@@ -29,6 +33,25 @@ pub async fn run(
         })
         .transpose()?;
 
+    if preview {
+        let grid = Grid::from_text(&text, h_align, VAlign::default())?;
+        println!();
+        print_grid_preview(&grid);
+        println!();
+
+        if io::stdin().is_terminal() {
+            print!("Push this message? [Y/n] ");
+            io::stdout().flush()?;
+            let mut input = String::new();
+            io::stdin().lock().read_line(&mut input)?;
+            let answer = input.trim().to_lowercase();
+            if !answer.is_empty() && answer != "y" {
+                println!("Aborted.");
+                return Ok(());
+            }
+        }
+    }
+
     let request = CreateMessageRequest {
         text: Some(text),
         grid: None,
@@ -44,4 +67,44 @@ pub async fn run(
     println!("Created message {}", message.id);
 
     Ok(())
+}
+
+fn print_grid_preview(grid: &Grid) {
+    let top = format!("┌{}┐", "───┬".repeat(BOARD_COLS - 1).to_string() + "───");
+    let mid = format!("├{}┤", "───┼".repeat(BOARD_COLS - 1).to_string() + "───");
+    let bot = format!("└{}┘", "───┴".repeat(BOARD_COLS - 1).to_string() + "───");
+
+    println!("{top}");
+    for (i, row) in grid.0.iter().enumerate() {
+        let cells: String = row
+            .iter()
+            .map(|cell| match cell {
+                CellContent::Char(c) => format!(" {} ", c),
+                CellContent::Color(color) => {
+                    let symbol = color_symbol(color);
+                    format!(" {} ", symbol)
+                }
+                CellContent::Blank => "   ".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("│");
+        println!("│{cells}│");
+        if i < BOARD_ROWS - 1 {
+            println!("{mid}");
+        }
+    }
+    println!("{bot}");
+}
+
+fn color_symbol(color: &Color) -> char {
+    match color {
+        Color::Red => '■',
+        Color::Orange => '■',
+        Color::Yellow => '■',
+        Color::Green => '■',
+        Color::Blue => '■',
+        Color::Violet => '■',
+        Color::White => '□',
+        Color::Black => '■',
+    }
 }

--- a/crates/herald-cli/src/main.rs
+++ b/crates/herald-cli/src/main.rs
@@ -51,6 +51,9 @@ enum Command {
         /// Expiry time in ISO-8601 format (e.g. "2025-12-31T23:59:59Z")
         #[arg(long)]
         expires: Option<String>,
+        /// Preview the message on the board before pushing
+        #[arg(long)]
+        preview: bool,
         #[command(flatten)]
         api: ApiArgs,
     },
@@ -155,8 +158,9 @@ async fn main() {
             text,
             align,
             expires,
+            preview,
             api,
-        } => commands::push::run(text, api.server, api.token, align, expires).await,
+        } => commands::push::run(text, api.server, api.token, align, expires, preview).await,
         Command::Countdown { command } => match command {
             CountdownCommand::Create {
                 label,

--- a/crates/herald-web/Cargo.toml
+++ b/crates/herald-web/Cargo.toml
@@ -8,6 +8,7 @@ description = "Web viewer for the Herald split-flap message board"
 [dependencies]
 herald-common = { workspace = true }
 uuid = { workspace = true, features = ["js"] }
+chrono = { workspace = true }
 leptos = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/herald-web/index.html
+++ b/crates/herald-web/index.html
@@ -316,6 +316,561 @@
                 margin: 0 auto;
             }
         }
+
+        /* ===== Admin Panel ===== */
+        .admin-container {
+            min-height: 100vh;
+            background: #0d0d0d;
+            color: #f0f0f0;
+            font-family: system-ui, -apple-system, sans-serif;
+            padding: 1rem;
+            max-width: 52rem;
+            margin: 0 auto;
+        }
+
+        .admin-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0.75rem 0;
+            border-bottom: 1px solid #333;
+            margin-bottom: 1.5rem;
+        }
+
+        .admin-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #f0f0f0;
+        }
+
+        .admin-nav {
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+        }
+
+        .admin-nav-link {
+            color: #888;
+            text-decoration: none;
+            font-size: 0.85rem;
+            transition: color 0.2s;
+        }
+
+        .admin-nav-link:hover {
+            color: #f0f0f0;
+        }
+
+        .admin-logout-btn {
+            background: none;
+            border: 1px solid #555;
+            color: #888;
+            padding: 0.3rem 0.75rem;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            transition: all 0.2s;
+        }
+
+        .admin-logout-btn:hover {
+            border-color: #f44336;
+            color: #f44336;
+        }
+
+        .admin-panels {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+
+        .admin-placeholder {
+            color: #666;
+            text-align: center;
+            padding: 3rem 0;
+            font-size: 0.9rem;
+        }
+
+        /* ===== Login Dialog ===== */
+        .login-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.85);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 200;
+            backdrop-filter: blur(4px);
+        }
+
+        .login-dialog {
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 12px;
+            padding: 2rem;
+            width: 20rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .login-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .login-subtitle {
+            color: #888;
+            font-size: 0.85rem;
+            text-align: center;
+        }
+
+        .login-error {
+            background: rgba(244, 67, 54, 0.15);
+            color: #f44336;
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            text-align: center;
+        }
+
+        .login-input {
+            background: #0d0d0d;
+            border: 1px solid #444;
+            border-radius: 6px;
+            padding: 0.6rem 0.75rem;
+            color: #f0f0f0;
+            font-size: 0.9rem;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .login-input:focus {
+            border-color: #4caf50;
+        }
+
+        .login-btn {
+            background: #4caf50;
+            border: none;
+            border-radius: 6px;
+            padding: 0.6rem;
+            color: white;
+            font-weight: 600;
+            font-size: 0.9rem;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .login-btn:hover {
+            background: #43a047;
+        }
+        /* ===== Message Composer ===== */
+        .composer {
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 8px;
+            padding: 1.25rem;
+        }
+
+        .composer-title {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: #f0f0f0;
+        }
+
+        .composer-form {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .composer-row {
+            display: flex;
+            gap: 0.75rem;
+        }
+
+        .composer-row > .composer-input-group {
+            flex: 1;
+        }
+
+        .composer-input-group {
+            display: flex;
+            flex-direction: column;
+            gap: 0.3rem;
+        }
+
+        .composer-label {
+            font-size: 0.75rem;
+            color: #888;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .composer-textarea {
+            background: #0d0d0d;
+            border: 1px solid #444;
+            border-radius: 6px;
+            padding: 0.6rem 0.75rem;
+            color: #f0f0f0;
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: 0.85rem;
+            resize: vertical;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .composer-textarea:focus {
+            border-color: #4caf50;
+        }
+
+        .composer-select,
+        .composer-datetime {
+            background: #0d0d0d;
+            border: 1px solid #444;
+            border-radius: 6px;
+            padding: 0.5rem 0.6rem;
+            color: #f0f0f0;
+            font-size: 0.85rem;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        .composer-select:focus,
+        .composer-datetime:focus {
+            border-color: #4caf50;
+        }
+
+        .composer-push-btn {
+            background: #4caf50;
+            border: none;
+            border-radius: 6px;
+            padding: 0.6rem;
+            color: white;
+            font-weight: 600;
+            font-size: 0.9rem;
+            cursor: pointer;
+            transition: background 0.2s;
+            margin-top: 0.25rem;
+        }
+
+        .composer-push-btn:hover:not(:disabled) {
+            background: #43a047;
+        }
+
+        .composer-push-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        /* ===== Live Preview Grid ===== */
+        .composer-preview {
+            margin-top: 1.25rem;
+            padding-top: 1rem;
+            border-top: 1px solid #333;
+        }
+
+        .composer-preview-title {
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: #888;
+            margin-bottom: 0.75rem;
+        }
+
+        .preview-grid {
+            display: grid;
+            grid-template-columns: repeat(22, 1fr);
+            gap: 1px;
+            background: #111;
+            border-radius: 6px;
+            padding: 4px;
+            max-width: 100%;
+        }
+
+        .preview-tile {
+            aspect-ratio: 1 / 1.2;
+            background: #2c2c2c;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 2px;
+            min-width: 0;
+        }
+
+        .preview-tile .flap-char {
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            font-size: clamp(0.45rem, 1.8vw, 0.85rem);
+            font-weight: 700;
+            color: #f0f0f0;
+            line-height: 1;
+        }
+
+        .preview-tile--blank {
+            background: #222;
+        }
+
+        .preview-tile--color {
+            border-radius: 2px;
+        }
+
+        .preview-tile--color .flap-char {
+            display: none;
+        }
+
+        /* ===== Toast Notifications ===== */
+        .toast {
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.8rem;
+            text-align: center;
+            margin-bottom: 0.75rem;
+            animation: toast-in 0.2s ease-out;
+        }
+
+        .toast-success {
+            background: rgba(76, 175, 80, 0.15);
+            color: #4caf50;
+            border: 1px solid rgba(76, 175, 80, 0.3);
+        }
+
+        .toast-error {
+            background: rgba(244, 67, 54, 0.15);
+            color: #f44336;
+            border: 1px solid rgba(244, 67, 54, 0.3);
+        }
+
+        @keyframes toast-in {
+            from { opacity: 0; transform: translateY(-0.5rem); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* ===== Queue Manager ===== */
+        .queue-mgr {
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 8px;
+            padding: 1.25rem;
+        }
+
+        .queue-mgr-title {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: #f0f0f0;
+        }
+
+        .queue-saving {
+            font-size: 0.75rem;
+            color: #ff9800;
+            font-weight: 400;
+            margin-left: 0.5rem;
+        }
+
+        .queue-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .queue-item {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: #0d0d0d;
+            border: 1px solid #2a2a2a;
+            border-radius: 6px;
+            padding: 0.5rem 0.75rem;
+            cursor: grab;
+            transition: all 0.15s;
+            user-select: none;
+        }
+
+        .queue-item:active {
+            cursor: grabbing;
+        }
+
+        .queue-item--current {
+            border-color: #4caf50;
+            background: rgba(76, 175, 80, 0.08);
+        }
+
+        .queue-item--drag-over {
+            border-color: #2196f3;
+            border-style: dashed;
+            background: rgba(33, 150, 243, 0.08);
+        }
+
+        .queue-item-handle {
+            color: #555;
+            font-size: 1rem;
+            cursor: grab;
+            flex-shrink: 0;
+        }
+
+        .queue-item-kind {
+            font-size: 0.85rem;
+            flex-shrink: 0;
+        }
+
+        .queue-item-label {
+            flex: 1;
+            font-size: 0.85rem;
+            color: #f0f0f0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .queue-item-pos {
+            font-size: 0.75rem;
+            color: #888;
+            flex-shrink: 0;
+        }
+
+        .queue-item-expiry {
+            font-size: 0.75rem;
+            color: #666;
+            flex-shrink: 0;
+            min-width: 5rem;
+            text-align: right;
+        }
+
+        .queue-item-badge {
+            font-size: 0.7rem;
+            color: #4caf50;
+            font-weight: 600;
+            flex-shrink: 0;
+            margin-left: 0.25rem;
+        }
+
+        .queue-empty {
+            color: #666;
+            font-size: 0.85rem;
+            text-align: center;
+            padding: 1.5rem 0;
+        }
+
+        /* ===== Countdown Manager ===== */
+        .countdown-mgr {
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 8px;
+            padding: 1.25rem;
+        }
+
+        .countdown-mgr-title {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: #f0f0f0;
+        }
+
+        .countdown-form {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin-bottom: 1.25rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid #333;
+        }
+
+        .countdown-form-row {
+            display: flex;
+            gap: 0.75rem;
+        }
+
+        .countdown-form-row > .composer-input-group {
+            flex: 1;
+        }
+
+        .countdown-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .countdown-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: #0d0d0d;
+            border: 1px solid #2a2a2a;
+            border-radius: 6px;
+            padding: 0.6rem 0.75rem;
+        }
+
+        .countdown-item-info {
+            display: flex;
+            flex-direction: column;
+            gap: 0.15rem;
+        }
+
+        .countdown-item-label {
+            font-weight: 600;
+            font-size: 0.85rem;
+            color: #f0f0f0;
+        }
+
+        .countdown-item-meta {
+            font-size: 0.75rem;
+            color: #888;
+        }
+
+        .countdown-item-remaining {
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: #4caf50;
+            min-width: 6rem;
+            text-align: right;
+        }
+
+        .countdown-item-remaining.expired {
+            color: #f44336;
+        }
+
+        .countdown-delete-btn {
+            background: none;
+            border: 1px solid #444;
+            color: #888;
+            padding: 0.25rem 0.5rem;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.75rem;
+            margin-left: 0.75rem;
+            transition: all 0.2s;
+        }
+
+        .countdown-delete-btn:hover {
+            border-color: #f44336;
+            color: #f44336;
+        }
+
+        .countdown-empty {
+            color: #666;
+            font-size: 0.85rem;
+            text-align: center;
+            padding: 1rem 0;
+        }
+
+        .countdown-create-btn {
+            background: #4caf50;
+            border: none;
+            border-radius: 6px;
+            padding: 0.5rem;
+            color: white;
+            font-weight: 600;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .countdown-create-btn:hover:not(:disabled) {
+            background: #43a047;
+        }
+
+        .countdown-create-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
     </style>
 </head>
 <body>

--- a/crates/herald-web/src/admin/auth.rs
+++ b/crates/herald-web/src/admin/auth.rs
@@ -1,0 +1,135 @@
+use leptos::prelude::*;
+
+/// Get the stored admin token from localStorage.
+fn get_stored_token() -> Option<String> {
+    web_sys::window()?
+        .local_storage()
+        .ok()??
+        .get_item("herald_admin_token")
+        .ok()?
+}
+
+/// Store the admin token in localStorage.
+fn store_token(token: &str) {
+    if let Some(storage) = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()
+    {
+        let _ = storage.set_item("herald_admin_token", token);
+    }
+}
+
+/// Clear the stored admin token.
+pub fn clear_token() {
+    if let Some(storage) = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()
+    {
+        let _ = storage.remove_item("herald_admin_token");
+    }
+}
+
+/// The main admin panel component.
+/// Shows login dialog if no token stored, otherwise shows the admin interface.
+#[component]
+pub fn AdminPanel() -> impl IntoView {
+    let token = RwSignal::new(get_stored_token());
+    let show_login = RwSignal::new(token.get_untracked().is_none());
+
+    // Provide token to child components via context
+    provide_context(token);
+    provide_context(show_login);
+
+    view! {
+        <div class="admin-container">
+            <header class="admin-header">
+                <h1 class="admin-title">"Herald Admin"</h1>
+                <nav class="admin-nav">
+                    <a href="/" class="admin-nav-link">"← Board"</a>
+                    {move || {
+                        if token.get().is_some() {
+                            Some(view! {
+                                <button class="admin-logout-btn"
+                                    on:click=move |_| {
+                                        clear_token();
+                                        token.set(None);
+                                        show_login.set(true);
+                                    }
+                                >"Logout"</button>
+                            })
+                        } else {
+                            None
+                        }
+                    }}
+                </nav>
+            </header>
+
+            {move || {
+                if show_login.get() {
+                    view! { <LoginDialog token=token show_login=show_login /> }.into_any()
+                } else {
+                    view! {
+                        <div class="admin-panels">
+                            <super::MessageComposer />
+                            <super::CountdownManager />
+                            <super::QueueManager />
+                        </div>
+                    }.into_any()
+                }
+            }}
+        </div>
+    }
+}
+
+/// Login dialog component.
+#[component]
+fn LoginDialog(token: RwSignal<Option<String>>, show_login: RwSignal<bool>) -> impl IntoView {
+    let input_value = RwSignal::new(String::new());
+    let error_msg = RwSignal::new(Option::<String>::None);
+
+    let do_submit = move || {
+        let val = input_value.get_untracked();
+        if val.trim().is_empty() {
+            error_msg.set(Some("Token cannot be empty".to_string()));
+            return;
+        }
+        store_token(val.trim());
+        token.set(Some(val.trim().to_string()));
+        show_login.set(false);
+        error_msg.set(None);
+    };
+
+    view! {
+        <div class="login-overlay">
+            <div class="login-dialog">
+                <div class="login-header-group">
+                    <h2 class="login-title">"Admin Login"</h2>
+                    <p class="login-subtitle">"Enter your Herald admin token"</p>
+                    {move || error_msg.get().map(|msg| view! {
+                        <div class="login-error">{msg}</div>
+                    })}
+                </div>
+
+                <input
+                    type="password"
+                    class="login-input"
+                    placeholder="Bearer token"
+                    prop:value=move || input_value.get()
+                    on:input=move |ev| {
+                        let val = event_target_value(&ev);
+                        input_value.set(val);
+                    }
+                    on:keydown=move |ev| {
+                        if ev.key() == "Enter" {
+                            do_submit();
+                        }
+                    }
+                />
+
+                <button class="login-btn" on:click=move |_| do_submit()>
+                    "Login"
+                </button>
+            </div>
+        </div>
+    }
+}

--- a/crates/herald-web/src/admin/composer.rs
+++ b/crates/herald-web/src/admin/composer.rs
@@ -1,0 +1,274 @@
+use herald_common::{
+    BOARD_COLS, BOARD_ROWS, CellContent, Color, CreateMessageRequest, Grid, HAlign, VAlign,
+};
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+/// Message composer with live grid preview.
+#[component]
+pub fn MessageComposer() -> impl IntoView {
+    let text = RwSignal::new(String::new());
+    let align = RwSignal::new("center".to_string());
+    let expires = RwSignal::new(String::new());
+    let toast = RwSignal::new(Option::<(String, bool)>::None);
+    let is_submitting = RwSignal::new(false);
+
+    let preview_grid = Memo::new(move |_| {
+        let t = text.get();
+        let h = parse_align(&align.get());
+        if t.is_empty() {
+            Grid::blank()
+        } else {
+            Grid::from_text(&t, h, VAlign::default()).unwrap_or_else(|_| Grid::blank())
+        }
+    });
+
+    // Auto-hide toast after 3 seconds
+    Effect::new(move |_| {
+        if toast.get().is_some() {
+            set_timeout(move || toast.set(None), std::time::Duration::from_secs(3));
+        }
+    });
+
+    let on_push = move |_| {
+        if is_submitting.get_untracked() {
+            return;
+        }
+        let t = text.get_untracked();
+        if t.trim().is_empty() {
+            toast.set(Some(("Message text cannot be empty".to_string(), false)));
+            return;
+        }
+
+        is_submitting.set(true);
+
+        let token_signal = expect_context::<RwSignal<Option<String>>>();
+        let show_login = expect_context::<RwSignal<bool>>();
+
+        let token = match token_signal.get_untracked() {
+            Some(t) => t,
+            None => {
+                toast.set(Some(("Not authenticated".to_string(), false)));
+                is_submitting.set(false);
+                return;
+            }
+        };
+
+        let h_align = parse_align(&align.get_untracked());
+        let expires_str = expires.get_untracked();
+        let expires_at = if expires_str.is_empty() {
+            None
+        } else {
+            match parse_expiry(&expires_str) {
+                Some(dt) => Some(dt),
+                None => {
+                    toast.set(Some(("Invalid expiry date format".to_string(), false)));
+                    is_submitting.set(false);
+                    return;
+                }
+            }
+        };
+
+        let request = CreateMessageRequest {
+            text: Some(t),
+            grid: None,
+            h_align,
+            v_align: VAlign::default(),
+            queue_position: None,
+            expires_at,
+        };
+
+        wasm_bindgen_futures::spawn_local(async move {
+            match post_message(&token, &request).await {
+                Ok(()) => {
+                    toast.set(Some(("Message pushed successfully!".to_string(), true)));
+                    text.set(String::new());
+                    expires.set(String::new());
+                }
+                Err(e) => {
+                    if e.contains("401") {
+                        super::auth::clear_token();
+                        token_signal.set(None);
+                        show_login.set(true);
+                    }
+                    toast.set(Some((format!("Error: {e}"), false)));
+                }
+            }
+            is_submitting.set(false);
+        });
+    };
+
+    view! {
+        <div class="composer">
+            <h2 class="composer-title">"Message Composer"</h2>
+
+            {move || toast.get().map(|(msg, success)| {
+                let class = if success { "toast toast-success" } else { "toast toast-error" };
+                view! { <div class=class>{msg}</div> }
+            })}
+
+            <div class="composer-form">
+                <div class="composer-input-group">
+                    <label class="composer-label">"Message"</label>
+                    <textarea
+                        class="composer-textarea"
+                        placeholder="Enter your message..."
+                        rows="3"
+                        prop:value=move || text.get()
+                        on:input=move |ev| {
+                            text.set(event_target_value(&ev));
+                        }
+                    />
+                </div>
+
+                <div class="composer-row">
+                    <div class="composer-input-group">
+                        <label class="composer-label">"Alignment"</label>
+                        <select
+                            class="composer-select"
+                            on:change=move |ev| {
+                                align.set(event_target_value(&ev));
+                            }
+                        >
+                            <option value="left">"Left"</option>
+                            <option value="center" selected>"Center"</option>
+                            <option value="right">"Right"</option>
+                        </select>
+                    </div>
+
+                    <div class="composer-input-group">
+                        <label class="composer-label">"Expires (optional)"</label>
+                        <input
+                            type="datetime-local"
+                            class="composer-datetime"
+                            prop:value=move || expires.get()
+                            on:input=move |ev| {
+                                expires.set(event_target_value(&ev));
+                            }
+                        />
+                    </div>
+                </div>
+
+                <button
+                    class="composer-push-btn"
+                    on:click=on_push
+                    disabled=move || is_submitting.get()
+                >
+                    {move || if is_submitting.get() { "Pushing..." } else { "Push Message" }}
+                </button>
+            </div>
+
+            <div class="composer-preview">
+                <h3 class="composer-preview-title">"Preview"</h3>
+                <div class="preview-grid">
+                    {move || {
+                        let grid = preview_grid.get();
+                        (0..BOARD_ROWS).map(|row| {
+                            let row_data = grid.0[row].clone();
+                            (0..BOARD_COLS).map(move |col| {
+                                let (class, style, ch) = cell_to_preview(&row_data[col]);
+                                view! {
+                                    <div class=class style=style>
+                                        <span class="flap-char">{ch}</span>
+                                    </div>
+                                }
+                            }).collect_view()
+                        }).collect_view()
+                    }}
+                </div>
+            </div>
+        </div>
+    }
+}
+
+fn cell_to_preview(cell: &CellContent) -> (&'static str, String, String) {
+    match cell {
+        CellContent::Char(c) => ("preview-tile", String::new(), c.to_string()),
+        CellContent::Color(color) => {
+            let css_color = color_to_css(color);
+            (
+                "preview-tile preview-tile--color",
+                format!("background: {css_color};"),
+                String::new(),
+            )
+        }
+        CellContent::Blank => (
+            "preview-tile preview-tile--blank",
+            String::new(),
+            " ".to_string(),
+        ),
+    }
+}
+
+fn color_to_css(color: &Color) -> &'static str {
+    match color {
+        Color::Red => "var(--color-red)",
+        Color::Orange => "var(--color-orange)",
+        Color::Yellow => "var(--color-yellow)",
+        Color::Green => "var(--color-green)",
+        Color::Blue => "var(--color-blue)",
+        Color::Violet => "var(--color-violet)",
+        Color::White => "var(--color-white)",
+        Color::Black => "var(--color-black)",
+    }
+}
+
+fn parse_align(s: &str) -> HAlign {
+    match s {
+        "left" => HAlign::Left,
+        "right" => HAlign::Right,
+        _ => HAlign::Center,
+    }
+}
+
+fn parse_expiry(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M") {
+        return Some(naive.and_utc());
+    }
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(naive.and_utc());
+    }
+    s.parse::<chrono::DateTime<chrono::Utc>>().ok()
+}
+
+/// POST a message to the server using the Fetch API.
+async fn post_message(token: &str, request: &CreateMessageRequest) -> Result<(), String> {
+    let body = serde_json::to_string(request).map_err(|e| e.to_string())?;
+
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+
+    let request_obj =
+        web_sys::Request::new_with_str_and_init(&format!("{base}/api/messages"), &opts)
+            .map_err(|e| format!("{e:?}"))?;
+
+    request_obj
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("{e:?}"))?;
+    request_obj
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request_obj))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("{}", resp.status()))
+    }
+}

--- a/crates/herald-web/src/admin/countdown.rs
+++ b/crates/herald-web/src/admin/countdown.rs
@@ -1,0 +1,420 @@
+use herald_common::{Countdown, CreateCountdownRequest, ListResponse, ZeroBehavior};
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+/// Countdown manager panel — create, list, and delete countdowns.
+#[component]
+pub fn CountdownManager() -> impl IntoView {
+    let countdowns = RwSignal::new(Vec::<Countdown>::new());
+    let toast = RwSignal::new(Option::<(String, bool)>::None);
+    let is_creating = RwSignal::new(false);
+    let tick = RwSignal::new(0u64);
+
+    // Form inputs
+    let label = RwSignal::new(String::new());
+    let target = RwSignal::new(String::new());
+    let zero_behavior = RwSignal::new("show_zero".to_string());
+
+    // Auto-hide toast after 3 seconds
+    Effect::new(move |_| {
+        if toast.get().is_some() {
+            set_timeout(move || toast.set(None), std::time::Duration::from_secs(3));
+        }
+    });
+
+    // Fetch countdowns on mount
+    Effect::new(move |_| {
+        let token_signal = expect_context::<RwSignal<Option<String>>>();
+        if let Some(token) = token_signal.get() {
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Ok(list) = fetch_countdowns(&token).await {
+                    countdowns.set(list);
+                }
+            });
+        }
+    });
+
+    // Poll every 10 seconds
+    set_interval(
+        move || {
+            let token_signal = expect_context::<RwSignal<Option<String>>>();
+            if let Some(token) = token_signal.get_untracked() {
+                wasm_bindgen_futures::spawn_local(async move {
+                    if let Ok(list) = fetch_countdowns(&token).await {
+                        countdowns.set(list);
+                    }
+                });
+            }
+        },
+        std::time::Duration::from_secs(10),
+    );
+
+    // Tick every second for live remaining time
+    set_interval(
+        move || tick.update(|t| *t += 1),
+        std::time::Duration::from_secs(1),
+    );
+
+    let on_create = move |_| {
+        if is_creating.get_untracked() {
+            return;
+        }
+
+        let lbl = label.get_untracked();
+        if lbl.trim().is_empty() {
+            toast.set(Some(("Label cannot be empty".to_string(), false)));
+            return;
+        }
+
+        let tgt = target.get_untracked();
+        if tgt.is_empty() {
+            toast.set(Some(("Target date/time is required".to_string(), false)));
+            return;
+        }
+
+        let parsed_target = match parse_datetime(&tgt) {
+            Some(dt) => dt,
+            None => {
+                toast.set(Some(("Invalid date/time format".to_string(), false)));
+                return;
+            }
+        };
+
+        let token_signal = expect_context::<RwSignal<Option<String>>>();
+        let show_login = expect_context::<RwSignal<bool>>();
+
+        let token = match token_signal.get_untracked() {
+            Some(t) => t,
+            None => {
+                toast.set(Some(("Not authenticated".to_string(), false)));
+                return;
+            }
+        };
+
+        let zb = parse_zero_behavior(&zero_behavior.get_untracked());
+
+        let request = CreateCountdownRequest {
+            label: lbl,
+            target: parsed_target,
+            format_template: String::new(),
+            zero_behavior: zb,
+            queue_position: None,
+        };
+
+        is_creating.set(true);
+
+        wasm_bindgen_futures::spawn_local(async move {
+            match create_countdown(&token, &request).await {
+                Ok(()) => {
+                    toast.set(Some(("Countdown created!".to_string(), true)));
+                    label.set(String::new());
+                    target.set(String::new());
+                    zero_behavior.set("show_zero".to_string());
+                    // Refresh list
+                    if let Ok(list) = fetch_countdowns(&token).await {
+                        countdowns.set(list);
+                    }
+                }
+                Err(e) => {
+                    if e.contains("401") {
+                        super::auth::clear_token();
+                        token_signal.set(None);
+                        show_login.set(true);
+                    }
+                    toast.set(Some((format!("Error: {e}"), false)));
+                }
+            }
+            is_creating.set(false);
+        });
+    };
+
+    let handle_delete = move |id: uuid::Uuid| {
+        let window = web_sys::window().unwrap();
+        let confirmed = window
+            .confirm_with_message("Delete this countdown?")
+            .unwrap_or(false);
+        if !confirmed {
+            return;
+        }
+
+        let token_signal = expect_context::<RwSignal<Option<String>>>();
+        let show_login = expect_context::<RwSignal<bool>>();
+
+        let token = match token_signal.get_untracked() {
+            Some(t) => t,
+            None => {
+                toast.set(Some(("Not authenticated".to_string(), false)));
+                return;
+            }
+        };
+
+        let id_str = id.to_string();
+        wasm_bindgen_futures::spawn_local(async move {
+            match delete_countdown(&token, &id_str).await {
+                Ok(()) => {
+                    toast.set(Some(("Countdown deleted".to_string(), true)));
+                    if let Ok(list) = fetch_countdowns(&token).await {
+                        countdowns.set(list);
+                    }
+                }
+                Err(e) => {
+                    if e.contains("401") {
+                        super::auth::clear_token();
+                        token_signal.set(None);
+                        show_login.set(true);
+                    }
+                    toast.set(Some((format!("Error: {e}"), false)));
+                }
+            }
+        });
+    };
+
+    view! {
+        <div class="countdown-mgr">
+            <h2 class="countdown-mgr-title">"Countdown Manager"</h2>
+
+            {move || toast.get().map(|(msg, success)| {
+                let class = if success { "toast toast-success" } else { "toast toast-error" };
+                view! { <div class=class>{msg}</div> }
+            })}
+
+            <div class="countdown-form">
+                <div class="countdown-form-row">
+                    <div class="composer-input-group">
+                        <label class="composer-label">"Label"</label>
+                        <input
+                            type="text"
+                            class="composer-datetime"
+                            placeholder="e.g. Product Launch"
+                            prop:value=move || label.get()
+                            on:input=move |ev| {
+                                label.set(event_target_value(&ev));
+                            }
+                        />
+                    </div>
+                    <div class="composer-input-group">
+                        <label class="composer-label">"Target"</label>
+                        <input
+                            type="datetime-local"
+                            class="composer-datetime"
+                            prop:value=move || target.get()
+                            on:input=move |ev| {
+                                target.set(event_target_value(&ev));
+                            }
+                        />
+                    </div>
+                </div>
+                <div class="countdown-form-row">
+                    <div class="composer-input-group">
+                        <label class="composer-label">"At Zero"</label>
+                        <select
+                            class="composer-select"
+                            prop:value=move || zero_behavior.get()
+                            on:change=move |ev| {
+                                zero_behavior.set(event_target_value(&ev));
+                            }
+                        >
+                            <option value="show_zero">"Show Zero"</option>
+                            <option value="remove">"Remove"</option>
+                            <option value="pause">"Pause"</option>
+                        </select>
+                    </div>
+                </div>
+                <button
+                    class="countdown-create-btn"
+                    on:click=on_create
+                    disabled=move || is_creating.get()
+                >
+                    {move || if is_creating.get() { "Creating..." } else { "Create Countdown" }}
+                </button>
+            </div>
+
+            <div class="countdown-list">
+                {move || {
+                    // Subscribe to tick so this re-renders every second
+                    let _ = tick.get();
+                    let items = countdowns.get();
+                    if items.is_empty() {
+                        view! { <div class="countdown-empty">"No countdowns yet"</div> }.into_any()
+                    } else {
+                        items.into_iter().map(|cd| {
+                            let id = cd.id;
+                            let remaining = format_remaining(&cd.target);
+                            let is_expired = remaining == "Expired";
+                            let remaining_class = if is_expired {
+                                "countdown-item-remaining expired"
+                            } else {
+                                "countdown-item-remaining"
+                            };
+                            let formatted_target = cd.target.format("%Y-%m-%d %H:%M UTC").to_string();
+                            view! {
+                                <div class="countdown-item">
+                                    <div class="countdown-item-info">
+                                        <span class="countdown-item-label">{cd.label.clone()}</span>
+                                        <span class="countdown-item-meta">{formatted_target}</span>
+                                    </div>
+                                    <span class=remaining_class>{remaining}</span>
+                                    <button
+                                        class="countdown-delete-btn"
+                                        on:click=move |_| handle_delete(id)
+                                    >"Delete"</button>
+                                </div>
+                            }
+                        }).collect_view().into_any()
+                    }
+                }}
+            </div>
+        </div>
+    }
+}
+
+fn format_remaining(target: &chrono::DateTime<chrono::Utc>) -> String {
+    let now = chrono::Utc::now();
+    let remaining = *target - now;
+    if remaining <= chrono::Duration::zero() {
+        "Expired".to_string()
+    } else {
+        let days = remaining.num_days();
+        let hours = remaining.num_hours() % 24;
+        let mins = remaining.num_minutes() % 60;
+        let secs = remaining.num_seconds() % 60;
+        if days > 0 {
+            format!("{days}d {hours}h {mins}m")
+        } else if hours > 0 {
+            format!("{hours}h {mins}m {secs}s")
+        } else if mins > 0 {
+            format!("{mins}m {secs}s")
+        } else {
+            format!("{secs}s")
+        }
+    }
+}
+
+fn parse_zero_behavior(s: &str) -> ZeroBehavior {
+    match s {
+        "remove" => ZeroBehavior::Remove,
+        "pause" => ZeroBehavior::Pause,
+        _ => ZeroBehavior::ShowZero,
+    }
+}
+
+fn parse_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M") {
+        return Some(naive.and_utc());
+    }
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+        return Some(naive.and_utc());
+    }
+    s.parse::<chrono::DateTime<chrono::Utc>>().ok()
+}
+
+async fn fetch_countdowns(token: &str) -> Result<Vec<Countdown>, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+
+    let request = web_sys::Request::new_with_str_and_init(&format!("{base}/api/countdowns"), &opts)
+        .map_err(|e| format!("{e:?}"))?;
+
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if !resp.ok() {
+        return Err(format!("{}", resp.status()));
+    }
+
+    let text = JsFuture::from(resp.text().map_err(|e| format!("{e:?}"))?)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+    let text_str = text.as_string().ok_or("not a string")?;
+    let list: ListResponse<Countdown> =
+        serde_json::from_str(&text_str).map_err(|e| e.to_string())?;
+    Ok(list.items)
+}
+
+async fn create_countdown(token: &str, req: &CreateCountdownRequest) -> Result<(), String> {
+    let body = serde_json::to_string(req).map_err(|e| e.to_string())?;
+
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&format!("{base}/api/countdowns"), &opts)
+        .map_err(|e| format!("{e:?}"))?;
+
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("{e:?}"))?;
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("{}", resp.status()))
+    }
+}
+
+async fn delete_countdown(token: &str, id: &str) -> Result<(), String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("DELETE");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+
+    let request =
+        web_sys::Request::new_with_str_and_init(&format!("{base}/api/countdowns/{id}"), &opts)
+            .map_err(|e| format!("{e:?}"))?;
+
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("{}", resp.status()))
+    }
+}

--- a/crates/herald-web/src/admin/mod.rs
+++ b/crates/herald-web/src/admin/mod.rs
@@ -1,0 +1,9 @@
+mod auth;
+mod composer;
+mod countdown;
+mod queue;
+
+pub use auth::AdminPanel;
+pub use composer::MessageComposer;
+pub use countdown::CountdownManager;
+pub use queue::QueueManager;

--- a/crates/herald-web/src/admin/queue.rs
+++ b/crates/herald-web/src/admin/queue.rs
@@ -1,0 +1,255 @@
+use herald_common::{QueueItem, QueueItemKind, QueueListResponse, ReorderQueueRequest};
+use leptos::prelude::*;
+use uuid::Uuid;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+/// Queue manager with drag-to-reorder.
+#[component]
+pub fn QueueManager() -> impl IntoView {
+    let items = RwSignal::new(Vec::<QueueItem>::new());
+    let current_index = RwSignal::new(-1i64);
+    let is_saving = RwSignal::new(false);
+    let toast = RwSignal::new(Option::<(String, bool)>::None);
+    let drag_over_index = RwSignal::new(Option::<usize>::None);
+
+    // Fetch on mount
+    Effect::new(move |_| {
+        let token_signal = expect_context::<RwSignal<Option<String>>>();
+        if let Some(token) = token_signal.get() {
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Ok(resp) = fetch_queue(&token).await {
+                    items.set(resp.items);
+                    current_index.set(resp.current_index);
+                }
+            });
+        }
+    });
+
+    // Poll every 10s
+    set_interval(
+        move || {
+            if is_saving.get_untracked() {
+                return;
+            }
+            let token_signal = expect_context::<RwSignal<Option<String>>>();
+            if let Some(token) = token_signal.get_untracked() {
+                wasm_bindgen_futures::spawn_local(async move {
+                    if let Ok(resp) = fetch_queue(&token).await {
+                        items.set(resp.items);
+                        current_index.set(resp.current_index);
+                    }
+                });
+            }
+        },
+        std::time::Duration::from_secs(10),
+    );
+
+    // Toast auto-hide
+    Effect::new(move |_| {
+        if toast.get().is_some() {
+            set_timeout(move || toast.set(None), std::time::Duration::from_secs(3));
+        }
+    });
+
+    view! {
+        <div class="queue-mgr">
+            <h2 class="queue-mgr-title">
+                "Queue"
+                {move || is_saving.get().then(|| view! {
+                    <span class="queue-saving">" Saving..."</span>
+                })}
+            </h2>
+
+            {move || toast.get().map(|(msg, success)| {
+                let class = if success { "toast toast-success" } else { "toast toast-error" };
+                view! { <div class=class>{msg}</div> }
+            })}
+
+            {move || {
+                let queue_items = items.get();
+                let cur_idx = current_index.get();
+                if queue_items.is_empty() {
+                    view! { <p class="queue-empty">"Queue is empty"</p> }.into_any()
+                } else {
+                    view! {
+                        <div class="queue-list">
+                            {queue_items.iter().enumerate().map(|(idx, item)| {
+                                let _id = item.id;
+                                let is_current = idx as i64 == cur_idx;
+                                let kind_icon = match item.kind {
+                                    QueueItemKind::Message => "\u{1F4DD}",
+                                    QueueItemKind::Countdown => "\u{23F1}",
+                                };
+                                let label = item.label.clone();
+                                let expiry = item.expires_at
+                                    .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+                                    .unwrap_or_else(|| "\u{2014}".to_string());
+                                let item_class = if is_current {
+                                    "queue-item queue-item--current"
+                                } else {
+                                    "queue-item"
+                                };
+                                let drag_class = move || {
+                                    if drag_over_index.get() == Some(idx) {
+                                        format!("{item_class} queue-item--drag-over")
+                                    } else {
+                                        item_class.to_string()
+                                    }
+                                };
+
+                                view! {
+                                    <div
+                                        class=drag_class
+                                        draggable="true"
+                                        on:dragstart=move |ev| {
+                                            if let Some(dt) = ev.data_transfer() {
+                                                let _ = dt.set_data("text/plain", &idx.to_string());
+                                            }
+                                        }
+                                        on:dragover=move |ev| {
+                                            ev.prevent_default();
+                                            drag_over_index.set(Some(idx));
+                                        }
+                                        on:dragleave=move |_| {
+                                            if drag_over_index.get_untracked() == Some(idx) {
+                                                drag_over_index.set(None);
+                                            }
+                                        }
+                                        on:drop=move |ev| {
+                                            ev.prevent_default();
+                                            drag_over_index.set(None);
+                                            let from_idx = ev.data_transfer()
+                                                .and_then(|dt| dt.get_data("text/plain").ok())
+                                                .and_then(|s| s.parse::<usize>().ok());
+                                            if let Some(from) = from_idx {
+                                                if from != idx {
+                                                    let mut new_items = items.get_untracked();
+                                                    let moved = new_items.remove(from);
+                                                    new_items.insert(idx, moved);
+                                                    items.set(new_items.clone());
+
+                                                    let order: Vec<Uuid> = new_items.iter().map(|i| i.id).collect();
+                                                    is_saving.set(true);
+                                                    let token_signal = expect_context::<RwSignal<Option<String>>>();
+                                                    if let Some(token) = token_signal.get_untracked() {
+                                                        wasm_bindgen_futures::spawn_local(async move {
+                                                            match reorder_queue(&token, order).await {
+                                                                Ok(resp) => {
+                                                                    items.set(resp.items);
+                                                                    current_index.set(resp.current_index);
+                                                                    toast.set(Some(("Queue reordered".to_string(), true)));
+                                                                }
+                                                                Err(e) => {
+                                                                    toast.set(Some((format!("Error: {e}"), false)));
+                                                                }
+                                                            }
+                                                            is_saving.set(false);
+                                                        });
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    >
+                                        <span class="queue-item-handle">{"\u{2261}"}</span>
+                                        <span class="queue-item-kind">{kind_icon}</span>
+                                        <span class="queue-item-label">{label}</span>
+                                        <span class="queue-item-pos">{"#"}{idx + 1}</span>
+                                        <span class="queue-item-expiry">{expiry}</span>
+                                        {is_current.then(|| view! {
+                                            <span class="queue-item-badge">{"\u{25B6} Now"}</span>
+                                        })}
+                                    </div>
+                                }
+                            }).collect_view()}
+                        </div>
+                    }.into_any()
+                }
+            }}
+        </div>
+    }
+}
+
+/// GET /api/queue
+async fn fetch_queue(token: &str) -> Result<QueueListResponse, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+
+    let request = web_sys::Request::new_with_str_and_init(&format!("{base}/api/queue"), &opts)
+        .map_err(|e| format!("{e:?}"))?;
+
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if !resp.ok() {
+        return Err(format!("{}", resp.status()));
+    }
+
+    let text = JsFuture::from(resp.text().map_err(|e| format!("{e:?}"))?)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let body = text.as_string().ok_or("response not a string")?;
+    serde_json::from_str(&body).map_err(|e| e.to_string())
+}
+
+/// PUT /api/queue/reorder
+async fn reorder_queue(token: &str, order: Vec<Uuid>) -> Result<QueueListResponse, String> {
+    let body = serde_json::to_string(&ReorderQueueRequest { order }).map_err(|e| e.to_string())?;
+
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("PUT");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+
+    let request =
+        web_sys::Request::new_with_str_and_init(&format!("{base}/api/queue/reorder"), &opts)
+            .map_err(|e| format!("{e:?}"))?;
+
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("{e:?}"))?;
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if !resp.ok() {
+        return Err(format!("{}", resp.status()));
+    }
+
+    let text = JsFuture::from(resp.text().map_err(|e| format!("{e:?}"))?)
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+
+    let body_str = text.as_string().ok_or("response not a string")?;
+    serde_json::from_str(&body_str).map_err(|e| e.to_string())
+}

--- a/crates/herald-web/src/main.rs
+++ b/crates/herald-web/src/main.rs
@@ -1,13 +1,58 @@
+mod admin;
 mod components;
 mod ws;
 
+use admin::AdminPanel;
 use components::Board;
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
 use ws::WebSocketState;
 
-/// Root application component.
+/// Simple client-side path tracking without leptos_router.
+fn use_location_path() -> ReadSignal<String> {
+    let (path, set_path) = signal(current_path());
+
+    // Listen for popstate events (back/forward navigation)
+    let closure = wasm_bindgen::closure::Closure::wrap(Box::new(move |_: web_sys::Event| {
+        set_path.set(current_path());
+    }) as Box<dyn Fn(_)>);
+
+    web_sys::window()
+        .unwrap()
+        .add_event_listener_with_callback("popstate", closure.as_ref().unchecked_ref())
+        .unwrap();
+    closure.forget();
+
+    path
+}
+
+fn current_path() -> String {
+    web_sys::window()
+        .unwrap()
+        .location()
+        .pathname()
+        .unwrap_or_else(|_| "/".to_string())
+}
+
+/// Root application component with client-side routing.
 #[component]
 fn App() -> impl IntoView {
+    let path = use_location_path();
+
+    view! {
+        {move || {
+            if path.get().starts_with("/admin") {
+                view! { <AdminPanel /> }.into_any()
+            } else {
+                view! { <BoardView /> }.into_any()
+            }
+        }}
+    }
+}
+
+/// The board viewer page (existing functionality).
+#[component]
+fn BoardView() -> impl IntoView {
     let ws_state = ws::use_websocket();
 
     view! {


### PR DESCRIPTION
## Description

Complete the web admin panel with countdown management, queue management, and add a CLI message preview feature.

### What's included

- **`--preview` flag for `herald push`** — Renders the message as a 6×22 ASCII grid in the terminal before sending. Prompts "Push this message? [Y/n]" for interactive sessions; skips the prompt when piped.
- **Web admin panel (`/admin`)** — Client-side routing between the board viewer and admin panel. Bearer token auth with localStorage persistence and automatic re-login on 401 responses.
- **Web message composer** — Text input with live 6×22 grid preview, alignment selector, optional expiry datetime picker, and push-to-server via Fetch API.
- **Web countdown manager** — Create form (label, target, zero behavior), countdown list with 10-second polling and 1-second live remaining-time updates, delete with confirmation dialog.
- **Web queue manager** — Sortable queue list using HTML5 drag-and-drop. Each item shows type icon, label, position, and expiry. Current item highlighted. Reorder calls `PUT /api/queue/reorder` with a "Saving..." indicator.

## Related Issues

Closes #55
Closes #56
Closes #57
Closes #58
Closes #59

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
