### PR TITLE
feat(web): add config panel to admin interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web message composer in the admin panel with live 6×22 grid preview, alignment selector, optional expiry picker, and push-to-server functionality
 - Web countdown manager in the admin panel with create form, live remaining-time display, and delete with confirmation
 - Web queue manager in the admin panel with drag-to-reorder, current item highlighting, and auto-refresh
+- Web config panel in the admin panel with editable fields for all server settings, per-field input types, change highlighting, and save with toast feedback
 
 ### Changed
 

--- a/crates/herald-web/index.html
+++ b/crates/herald-web/index.html
@@ -871,6 +871,110 @@
             opacity: 0.5;
             cursor: not-allowed;
         }
+
+        /* ===== Config Panel ===== */
+        .config-panel {
+            background: #1a1a1a;
+            border: 1px solid #333;
+            border-radius: 8px;
+            padding: 1.25rem;
+        }
+
+        .config-panel-title {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: #f0f0f0;
+        }
+
+        .config-form {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .config-field {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+
+        .config-field-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .config-field-label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #f0f0f0;
+        }
+
+        .config-field-key {
+            font-size: 0.7rem;
+            color: #666;
+            font-family: 'JetBrains Mono', monospace;
+        }
+
+        .config-field-desc {
+            font-size: 0.75rem;
+            color: #888;
+            margin-bottom: 0.15rem;
+        }
+
+        .config-input,
+        .config-select {
+            background: #0d0d0d;
+            border: 1px solid #444;
+            border-radius: 6px;
+            padding: 0.5rem 0.6rem;
+            color: #f0f0f0;
+            font-size: 0.85rem;
+            outline: none;
+            transition: border-color 0.2s;
+            max-width: 16rem;
+        }
+
+        .config-input:focus,
+        .config-select:focus {
+            border-color: #4caf50;
+        }
+
+        .config-input.modified,
+        .config-select.modified {
+            border-color: #ff9800;
+        }
+
+        .config-save-btn {
+            background: #4caf50;
+            border: none;
+            border-radius: 6px;
+            padding: 0.6rem 1.5rem;
+            color: white;
+            font-weight: 600;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: background 0.2s;
+            align-self: flex-start;
+            margin-top: 0.5rem;
+        }
+
+        .config-save-btn:hover:not(:disabled) {
+            background: #43a047;
+        }
+
+        .config-save-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .config-loading {
+            color: #666;
+            font-size: 0.85rem;
+            text-align: center;
+            padding: 1.5rem 0;
+        }
     </style>
 </head>
 <body>

--- a/crates/herald-web/src/admin/auth.rs
+++ b/crates/herald-web/src/admin/auth.rs
@@ -73,6 +73,7 @@ pub fn AdminPanel() -> impl IntoView {
                             <super::MessageComposer />
                             <super::CountdownManager />
                             <super::QueueManager />
+                            <super::ConfigPanel />
                         </div>
                     }.into_any()
                 }

--- a/crates/herald-web/src/admin/config.rs
+++ b/crates/herald-web/src/admin/config.rs
@@ -1,0 +1,346 @@
+use herald_common::UpdateConfigRequest;
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+
+/// Config key metadata for rendering appropriate input types.
+struct ConfigField {
+    key: &'static str,
+    label: &'static str,
+    description: &'static str,
+    input_type: InputType,
+}
+
+enum InputType {
+    Number,
+    Select(&'static [&'static str]),
+}
+
+const CONFIG_FIELDS: &[ConfigField] = &[
+    ConfigField {
+        key: "rotation_interval_seconds",
+        label: "Rotation Interval",
+        description: "Seconds between queue item rotation",
+        input_type: InputType::Number,
+    },
+    ConfigField {
+        key: "countdown_refresh_seconds",
+        label: "Countdown Refresh",
+        description: "Seconds between countdown display updates",
+        input_type: InputType::Number,
+    },
+    ConfigField {
+        key: "default_h_align",
+        label: "Default H-Align",
+        description: "Default horizontal alignment for new messages",
+        input_type: InputType::Select(&["left", "center", "right"]),
+    },
+    ConfigField {
+        key: "default_v_align",
+        label: "Default V-Align",
+        description: "Default vertical alignment for new messages",
+        input_type: InputType::Select(&["top", "middle"]),
+    },
+    ConfigField {
+        key: "default_color",
+        label: "Default Color",
+        description: "Default tile color",
+        input_type: InputType::Select(&[
+            "red", "orange", "yellow", "green", "blue", "violet", "white", "black",
+        ]),
+    },
+    ConfigField {
+        key: "countdown_zero_behavior",
+        label: "Countdown Zero Behavior",
+        description: "What happens when a countdown reaches zero",
+        input_type: InputType::Select(&["show_zero", "remove", "pause"]),
+    },
+];
+
+fn get_value_str(map: &serde_json::Map<String, serde_json::Value>, key: &str) -> String {
+    map.get(key)
+        .map(|v| match v {
+            serde_json::Value::String(s) => s.clone(),
+            serde_json::Value::Number(n) => n.to_string(),
+            other => other.to_string(),
+        })
+        .unwrap_or_default()
+}
+
+/// Admin config panel for server settings.
+#[component]
+pub fn ConfigPanel() -> impl IntoView {
+    let original = RwSignal::new(serde_json::Map::new());
+    let edited = RwSignal::new(serde_json::Map::new());
+    let is_saving = RwSignal::new(false);
+    let is_loading = RwSignal::new(true);
+    let toast = RwSignal::new(Option::<(String, bool)>::None);
+
+    let has_changes = Memo::new(move |_| original.get() != edited.get());
+
+    let token_signal = expect_context::<RwSignal<Option<String>>>();
+    let show_login = expect_context::<RwSignal<bool>>();
+
+    // Auto-hide toast after 3 seconds
+    Effect::new(move |_| {
+        if toast.get().is_some() {
+            set_timeout(move || toast.set(None), std::time::Duration::from_secs(3));
+        }
+    });
+
+    // Load config on mount
+    {
+        wasm_bindgen_futures::spawn_local(async move {
+            let token = match token_signal.get_untracked() {
+                Some(t) => t,
+                None => {
+                    is_loading.set(false);
+                    return;
+                }
+            };
+            match fetch_config(&token).await {
+                Ok(map) => {
+                    original.set(map.clone());
+                    edited.set(map);
+                }
+                Err(e) => {
+                    if e.contains("401") {
+                        super::auth::clear_token();
+                        token_signal.set(None);
+                        show_login.set(true);
+                    }
+                    toast.set(Some((format!("Failed to load config: {e}"), false)));
+                }
+            }
+            is_loading.set(false);
+        });
+    }
+
+    let on_save = move |_| {
+        if is_saving.get_untracked() {
+            return;
+        }
+
+        let token = match token_signal.get_untracked() {
+            Some(t) => t,
+            None => {
+                toast.set(Some(("Not authenticated".to_string(), false)));
+                return;
+            }
+        };
+
+        let orig = original.get_untracked();
+        let edit = edited.get_untracked();
+
+        // Only send changed values
+        let mut changed = serde_json::Map::new();
+        for (k, v) in &edit {
+            if orig.get(k) != Some(v) {
+                changed.insert(k.clone(), v.clone());
+            }
+        }
+
+        if changed.is_empty() {
+            return;
+        }
+
+        is_saving.set(true);
+
+        wasm_bindgen_futures::spawn_local(async move {
+            match save_config(&token, changed).await {
+                Ok(()) => {
+                    // Update original to match edited
+                    original.set(edited.get_untracked());
+                    toast.set(Some(("Config saved successfully!".to_string(), true)));
+                }
+                Err(e) => {
+                    if e.contains("401") {
+                        super::auth::clear_token();
+                        token_signal.set(None);
+                        show_login.set(true);
+                    }
+                    toast.set(Some((format!("Error: {e}"), false)));
+                }
+            }
+            is_saving.set(false);
+        });
+    };
+
+    view! {
+        <div class="config-panel">
+            <h2 class="config-panel-title">"Server Config"</h2>
+
+            {move || toast.get().map(|(msg, success)| {
+                let class = if success { "toast toast-success" } else { "toast toast-error" };
+                view! { <div class=class>{msg}</div> }
+            })}
+
+            {move || {
+                if is_loading.get() {
+                    view! { <div class="config-loading">"Loading config…"</div> }.into_any()
+                } else {
+                    let field_views = CONFIG_FIELDS.iter().map(|field| {
+                        let key = field.key;
+                        let label = field.label;
+                        let description = field.description;
+
+                        let current_value = Memo::new(move |_| {
+                            get_value_str(&edited.get(), key)
+                        });
+
+                        let is_modified = Memo::new(move |_| {
+                            let orig = original.get();
+                            let edit = edited.get();
+                            orig.get(key) != edit.get(key)
+                        });
+
+                        let input_view = match &field.input_type {
+                            InputType::Number => {
+                                view! {
+                                    <input
+                                        type="number"
+                                        class=move || if is_modified.get() { "config-input modified" } else { "config-input" }
+                                        prop:value=move || current_value.get()
+                                        on:input=move |ev| {
+                                            let val = event_target_value(&ev);
+                                            edited.update(|map| {
+                                                if let Ok(n) = val.parse::<i64>() {
+                                                    map.insert(key.to_string(), serde_json::Value::Number(n.into()));
+                                                }
+                                            });
+                                        }
+                                    />
+                                }.into_any()
+                            }
+                            InputType::Select(options) => {
+                                let options = *options;
+                                view! {
+                                    <select
+                                        class=move || if is_modified.get() { "config-select modified" } else { "config-select" }
+                                        on:change=move |ev| {
+                                            let val = event_target_value(&ev);
+                                            edited.update(|map| {
+                                                map.insert(key.to_string(), serde_json::Value::String(val));
+                                            });
+                                        }
+                                    >
+                                        {options.iter().map(|opt| {
+                                            let opt_val = *opt;
+                                            view! {
+                                                <option
+                                                    value=opt_val
+                                                    selected=move || current_value.get() == opt_val
+                                                >
+                                                    {opt_val}
+                                                </option>
+                                            }
+                                        }).collect_view()}
+                                    </select>
+                                }.into_any()
+                            }
+                        };
+
+                        view! {
+                            <div class="config-field">
+                                <div class="config-field-header">
+                                    <span class="config-field-label">{label}</span>
+                                    <span class="config-field-key">{key}</span>
+                                </div>
+                                <span class="config-field-desc">{description}</span>
+                                {input_view}
+                            </div>
+                        }
+                    }).collect_view();
+
+                    view! {
+                        <div class="config-form">
+                            {field_views}
+                            <button
+                                class="config-save-btn"
+                                on:click=on_save
+                                disabled=move || !has_changes.get() || is_saving.get()
+                            >
+                                {move || if is_saving.get() { "Saving..." } else { "Save Changes" }}
+                            </button>
+                        </div>
+                    }.into_any()
+                }
+            }}
+        </div>
+    }
+}
+
+async fn fetch_config(token: &str) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+
+    let request = web_sys::Request::new_with_str_and_init(&format!("{base}/api/config"), &opts)
+        .map_err(|e| format!("{e:?}"))?;
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if !resp.ok() {
+        return Err(format!("{}", resp.status()));
+    }
+
+    let text = JsFuture::from(resp.text().unwrap())
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+    let text_str = text.as_string().ok_or("not a string")?;
+    serde_json::from_str(&text_str).map_err(|e| e.to_string())
+}
+
+async fn save_config(
+    token: &str,
+    values: serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let request_body = UpdateConfigRequest { values };
+    let body = serde_json::to_string(&request_body).map_err(|e| e.to_string())?;
+
+    let window = web_sys::window().ok_or("no window")?;
+    let base = window
+        .location()
+        .origin()
+        .map_err(|_| "no origin".to_string())?;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("PUT");
+    opts.set_mode(web_sys::RequestMode::SameOrigin);
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&format!("{base}/api/config"), &opts)
+        .map_err(|e| format!("{e:?}"))?;
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("{e:?}"))?;
+    request
+        .headers()
+        .set("Authorization", &format!("Bearer {token}"))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("{e:?}"))?;
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|_| "not a Response")?;
+
+    if resp.ok() {
+        Ok(())
+    } else {
+        Err(format!("{}", resp.status()))
+    }
+}

--- a/crates/herald-web/src/admin/mod.rs
+++ b/crates/herald-web/src/admin/mod.rs
@@ -1,9 +1,11 @@
 mod auth;
 mod composer;
+mod config;
 mod countdown;
 mod queue;
 
 pub use auth::AdminPanel;
 pub use composer::MessageComposer;
+pub use config::ConfigPanel;
 pub use countdown::CountdownManager;
 pub use queue::QueueManager;


### PR DESCRIPTION
## Description

Add a configuration panel to the web admin interface for viewing and editing all server settings.

### What's included

- **Config panel component** — Displays all server config keys in an editable form with appropriate input types: number inputs for interval settings, dropdowns for alignment/color/behavior options.
- **Dirty state tracking** — Modified fields are highlighted with an orange border. The "Save Changes" button is only enabled when there are unsaved changes.
- **Save flow** — Only changed values are sent via `PUT /api/config`. Success/error toast notifications, with 401 handling that clears the token and re-prompts login.
- **Config key metadata** — Each field shows its label, config key, and a human-readable description.

## Related Issues

Closes #60

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
