### PR TITLE
feat(infra): add multi-stage Dockerfile with cargo-chef caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+.git/
+.github/
+docs/
+*.md
+!README.md
+.env
+.env.*
+*.db
+*.db-wal
+*.db-shm
+crates/herald-web/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web countdown manager in the admin panel with create form, live remaining-time display, and delete with confirmation
 - Web queue manager in the admin panel with drag-to-reorder, current item highlighting, and auto-refresh
 - Web config panel in the admin panel with editable fields for all server settings, per-field input types, change highlighting, and save with toast feedback
+- Multi-stage Dockerfile with cargo-chef dependency caching, Trunk/WASM web build, and minimal `debian:bookworm-slim` runtime image
+- Docker Compose configuration with persistent SQLite volume and environment variable support
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+# =============================================================================
+# Stage 1: Dependency planner (cargo-chef)
+# =============================================================================
+FROM rust:1-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# =============================================================================
+# Stage 2: Build the Herald server binary
+# =============================================================================
+FROM chef AS server-builder
+
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies only (cached unless Cargo.toml/Cargo.lock change)
+RUN cargo chef cook --release --recipe-path recipe.json -p herald-server
+
+# Copy source and build the actual binary
+COPY . .
+RUN cargo build --release -p herald-server
+
+# =============================================================================
+# Stage 3: Build the Leptos/Wasm web frontend
+# =============================================================================
+FROM rust:1-bookworm AS web-builder
+
+RUN rustup target add wasm32-unknown-unknown \
+    && cargo install trunk
+
+WORKDIR /app
+COPY . .
+
+RUN cd crates/herald-web && trunk build --release
+
+# =============================================================================
+# Stage 4: Minimal runtime image
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
+
+# Install runtime dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN useradd --create-home --shell /bin/bash herald
+
+WORKDIR /home/herald
+
+# Copy server binary
+COPY --from=server-builder /app/target/release/herald-server /usr/local/bin/herald-server
+
+# Copy web assets
+COPY --from=web-builder /app/crates/herald-web/dist ./static
+
+# Create data directory for SQLite
+RUN mkdir -p /data && chown herald:herald /data
+
+USER herald
+
+# Configuration
+ENV HERALD_PORT=3000 \
+    HERALD_DB_PATH=/data/herald.db \
+    HERALD_WEB_DIR=/home/herald/static \
+    HERALD_LOG_LEVEL=info
+
+EXPOSE 3000
+
+ENTRYPOINT ["herald-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  herald:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - herald_data:/data
+    environment:
+      HERALD_ADMIN_TOKEN: "${HERALD_ADMIN_TOKEN:-changeme}"
+      HERALD_DB_PATH: /data/herald.db
+      HERALD_PORT: "3000"
+      HERALD_LOG_LEVEL: info
+    restart: unless-stopped
+
+volumes:
+  herald_data:


### PR DESCRIPTION
## Description

Add Docker support for building and deploying Herald as a container.

### What's included

- **Multi-stage Dockerfile** — 4-stage build using `cargo-chef` for dependency caching:
  1. **Planner** — generates a dependency recipe for cache-efficient rebuilds
  2. **Server builder** — compiles `herald-server` in release mode (deps cached separately from source)
  3. **Web builder** — installs Trunk, builds the Leptos/WASM frontend
  4. **Runtime** — minimal `debian:bookworm-slim` image with non-root `herald` user, server binary, and web assets
- **Docker Compose** — single-service config with persistent SQLite volume (`herald_data:/data`), environment variable support, and `unless-stopped` restart policy
- **`.dockerignore`** — excludes `target/`, `.git/`, docs, and SQLite files to keep the build context small

### Usage

```bash
HERALD_ADMIN_TOKEN=secret docker compose up --build
```

## Related Issues

Closes #61

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
