### PR TITLE
docs: update README, ARCHITECTURE, and DEPLOYMENT for Phases 5–7

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,17 @@ Herald is an open-source, split-flap / Vestaboard-style digital message board an
 - **Simple auth** — single admin with bearer-token authentication
 - **SQLite persistence** — data survives restarts
 - **PowerShell helper scripts** — quick admin without remembering curl syntax
+- **CLI admin tools** — `herald push`, `herald countdown`, `herald queue`, `herald config` subcommands for full board management from the terminal
+- **Message preview** — `--preview` flag renders an ASCII grid preview before pushing
+- **Color markup** — inline `{red}text{/red}` syntax for colored text in messages
+- **Web admin panel** — `/admin` route with token auth, message composer with live preview, countdown manager, queue manager with drag-to-reorder, and server config editor
+- **Docker deployment** — multi-stage Dockerfile with cargo-chef caching, Docker Compose with healthcheck and persistent volumes
+- **Graceful shutdown** — clean SIGTERM/SIGINT handling with WebSocket client notification
+- **Structured logging** — HTTP request/response tracing with optional JSON output format
 - **All Rust** — monorepo, one toolchain
 
 ### Roadmap (not yet implemented)
 
-- Admin web panel and CLI admin subcommands
-- Docker packaging and deployment tooling
 - Sound effects, themes, scheduling, rate limiting
 
 ---
@@ -129,6 +134,32 @@ $env:HERALD_ADMIN_TOKEN = "your-token-here"
 .\scripts\set-rotation-interval.ps1 -Seconds 15
 ```
 
+### 4b. CLI admin commands
+
+Herald includes built-in admin subcommands (no scripts needed):
+
+```bash
+# Push a message
+herald push "HELLO WORLD" --token secret
+herald push "LEFT ALIGNED" --align left --token secret
+herald push "PREVIEW FIRST" --preview --token secret
+
+# Manage countdowns
+herald countdown create --label "LAUNCH" --target "2026-12-31T00:00:00Z" --token secret
+herald countdown list --token secret
+herald countdown delete <UUID> --token secret
+
+# View and reorder the queue
+herald queue list --token secret
+herald queue reorder <id1> <id2> <id3> --token secret
+
+# View and update config
+herald config get --token secret
+herald config set rotation_interval_seconds 15 --token secret
+```
+
+The `--token` flag can also be set via `HERALD_ADMIN_TOKEN` environment variable.
+
 ### 5. Open the web viewer
 
 **Option A — Served from the server (production-style):**
@@ -155,6 +186,30 @@ trunk serve
 ```
 
 Open `http://localhost:8080` — Trunk serves the web viewer with live-reload and proxies API/WebSocket requests to the server.
+
+### 5b. Web admin panel
+
+Navigate to `http://localhost:3000/admin` (or `http://localhost:8080/admin` in dev mode) to access the admin panel. Features:
+- **Message Composer** — type a message and see a live 6×22 grid preview, select alignment, set optional expiry, and push
+- **Countdown Manager** — create, view (with live remaining time), and delete countdowns
+- **Queue Manager** — view queue items and drag-to-reorder
+- **Config Editor** — view and edit all server settings
+
+You'll be prompted for your admin token on first visit. The token is stored in your browser's localStorage.
+
+### 6. Docker deployment
+
+```bash
+# Quick start with Docker Compose
+HERALD_ADMIN_TOKEN=your-secret docker compose up --build
+
+# Or customize via .env file (see .env.example)
+cp .env.example .env
+# Edit .env with your settings
+docker compose up -d
+```
+
+The Docker image uses a multi-stage build with cargo-chef for dependency caching. The runtime image is based on `debian:bookworm-slim` and includes a healthcheck on `/api/health`.
 
 ### Using curl instead
 
@@ -299,6 +354,7 @@ Zero behaviors: `show_zero`, `remove`, `pause`, `show_message`.
 | `HERALD_PORT` | `3000` | Server listen port |
 | `HERALD_LOG_LEVEL` | `info` | Log level (trace, debug, info, warn, error) |
 | `HERALD_WEB_DIR` | `./web-dist` | Directory for compiled web viewer assets (auto-detected) |
+| `HERALD_LOG_FORMAT` | *(pretty)* | Log output format: `json` for structured logs, default is human-readable |
 
 ---
 
@@ -306,7 +362,7 @@ Zero behaviors: `show_zero`, `remove`, `pause`, `show_message`.
 
 ```bash
 cargo build                       # Debug build (server + CLI)
-cargo test                        # Run all tests (~90 tests)
+cargo test                        # Run all tests (103+ tests)
 cargo clippy                      # Lint
 cargo fmt                         # Format
 cargo run -p herald-server        # Start the server

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 > Architectural foundation for the Herald split-flap message board system.
 > This document describes the system's components, how they communicate, and how the codebase is organized.
 >
-> **Implementation status:** Phases 1–4 are complete (server, CLI viewer with animation). The web viewer (`herald-web`), admin CLI subcommands, Docker packaging, and deployment tooling described below are part of the planned architecture but are not yet implemented. See [ROADMAP.md](./ROADMAP.md) for details.
+> **Implementation status:** Phases 1–7 are implemented: server with REST API, WebSocket, SQLite persistence, rotation engine, countdown logic, CLI viewer with split-flap animation, web viewer with 3D CSS flips, CLI admin subcommands (`push`, `countdown`, `queue`, `config`), web admin panel (message composer, countdown manager, queue manager, config editor), color markup parser, Docker packaging with multi-stage build, graceful shutdown, and structured logging. Phase 8 (sound effects, themes, scheduling, rate limiting) is planned. See [ROADMAP.md](./ROADMAP.md) for details.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Herald — Deployment Guide
 
-> **Note:** This document describes the *planned* deployment setup for production use. Docker, systemd units, and reverse proxy configurations are not yet implemented (see [ROADMAP.md](./ROADMAP.md) Phase 7). For current usage, see the [README](../README.md) Quick Start section.
+> **Note:** Docker deployment (Dockerfile, docker-compose.yml) is implemented and ready for use. Systemd service units and reverse proxy configurations are planned for a future release. See also the [README](../README.md) Quick Start section.
 
 This guide covers everything you need to deploy Herald, from Docker containers to bare-metal installs. By the end, you should have a running Herald instance accessible via web browser or CLI viewer.
 
@@ -134,6 +134,8 @@ EXPOSE 3000
 ENTRYPOINT ["herald", "serve"]
 ```
 
+> **Note:** The example above uses the old double-underscore (`HERALD_SERVER__PORT`) env var format and a simplified build. See the actual `Dockerfile` in the repository root for the current implementation, which uses `cargo-chef` for cached dependency builds, flat env vars (`HERALD_PORT`, `HERALD_DB_PATH`, etc.), and `curl` for health checks.
+
 ### 2.2 Docker Compose
 
 Create a `docker-compose.yml` in the repository root:
@@ -156,6 +158,8 @@ services:
 volumes:
   herald_data:
 ```
+
+> **Note:** The example above uses the old double-underscore env var format (`HERALD_AUTH__ADMIN_TOKEN`, `HERALD_SERVER__PORT`, etc.). The actual `docker-compose.yml` in the repository root uses the flat format (`HERALD_ADMIN_TOKEN`, `HERALD_PORT`, `HERALD_DB_PATH`, `HERALD_WEB_DIR`, `HERALD_LOG_LEVEL`). See that file for the current implementation.
 
 > **Important:** Replace `your-secret-token-here` with a strong, random token. Generate one with:
 > ```bash
@@ -403,6 +407,8 @@ path = "/ws"
 
 Environment variables follow the pattern `HERALD_<SECTION>__<KEY>` — note the **double underscore** (`__`) separating nested TOML table names from key names.
 
+> **Note:** The current Herald server implementation uses **flat** environment variable names instead of the double-underscore nested format shown in the table below. The actual env vars are: `HERALD_PORT`, `HERALD_DB_PATH`, `HERALD_WEB_DIR`, `HERALD_ADMIN_TOKEN`, `HERALD_LOG_LEVEL`, and `HERALD_LOG_FORMAT`. See the `Dockerfile` and `.env.example` in the repository root for the canonical list.
+
 | TOML Key                            | Environment Variable                      | Example Value             |
 |-------------------------------------|-------------------------------------------|---------------------------|
 | `server.bind_address`               | `HERALD_SERVER__BIND_ADDRESS`             | `0.0.0.0`                |
@@ -421,7 +427,7 @@ Environment variables follow the pattern `HERALD_<SECTION>__<KEY>` — note the 
 **Example:** Override the port and admin token via environment variables:
 
 ```bash
-HERALD_SERVER__PORT=8080 HERALD_AUTH__ADMIN_TOKEN="super-secret" herald serve
+HERALD_PORT=8080 HERALD_ADMIN_TOKEN="super-secret" herald-server
 ```
 
 ---
@@ -532,7 +538,7 @@ sudo caddy start --config /etc/caddy/Caddyfile
 
 ### SQLite Database
 
-Herald stores all data in a single SQLite file. By default, this is `./herald.db` (relative to the working directory), configurable via `database.path` in `herald.toml` or `HERALD_DATABASE__PATH`.
+Herald stores all data in a single SQLite file. By default, this is `./herald.db` (relative to the working directory), configurable via `database.path` in `herald.toml` or the `HERALD_DB_PATH` environment variable.
 
 **First run:** The database file is created automatically. Herald runs all pending migrations on startup — no manual setup required.
 
@@ -550,7 +556,7 @@ sqlite3 herald.db ".backup herald-backup.db"
 
 - **Always use a named volume** (as shown in the Docker Compose example) to persist data across container rebuilds.
 - **Never store the database inside the container's writable layer** — it will be lost on `docker compose down`.
-- The volume mount point should match `HERALD_DATABASE__PATH` (default: `/data/herald.db`).
+- The volume mount point should match `HERALD_DB_PATH` (default: `/data/herald.db`).
 
 ```yaml
 volumes:


### PR DESCRIPTION
## Description

Update project documentation to reflect all features implemented through issues #49–#65.

### What's included

- **README.md** — Added 7 newly implemented features to the features list (CLI admin tools, message preview, color markup, web admin panel, Docker, graceful shutdown, structured logging). Trimmed the roadmap to only Phase 8 items. Added new sections: CLI admin commands (4b), web admin panel (5b), Docker deployment (6). Added `HERALD_LOG_FORMAT` to env vars table. Updated test count to 103+.
- **ARCHITECTURE.md** — Updated implementation status from "Phases 1–4 complete" to "Phases 1–7 implemented" with a comprehensive feature list.
- **DEPLOYMENT.md** — Removed "planned/not yet implemented" notice since Docker is now real. Added clarifying notes about actual Dockerfile (cargo-chef) vs the example. Fixed env var references from old double-underscore format to actual flat format.

## Related Issues

Relates to #49, #50, #51, #52, #53, #54, #55, #56, #57, #58, #59, #60, #61, #62, #63, #64, #65

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)
