### PR TITLE
feat: add flip sound effects, board themes, and Docker release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -77,6 +78,41 @@ jobs:
             herald-server-*.tar.gz
             herald-server-*.zip
             herald-server-*.sha256
+
+  docker:
+    name: Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional mechanical "clack" sound effect on web tile flips using the Web Audio API — programmatic noise-burst synthesis with band-pass filter, staggered per-column to match the visual cascade
+- Mute/unmute toggle button (🔊/🔇) in the bottom-left corner of the web viewer — persists preference in `localStorage`, keyboard-focusable with `aria-label`, respects `prefers-reduced-motion`
+- Board theme system with three built-in themes: **Classic** (black background, warm yellow text), **Dark** (dark gray background, white text — default), and **Custom** (user-defined hex colors via config)
+- Theme selector in the web admin config panel and `herald config set theme <name>` CLI command
+- Custom theme color config keys: `theme_custom_board_bg`, `theme_custom_tile_bg`, `theme_custom_char_color` (validated `#RRGGBB` hex)
+- Theme-aware rendering in the CLI viewer — Classic theme uses warm yellow characters and dark gray borders
+- Docker image build and push to `ghcr.io` in the release workflow, with semver tags and GitHub Actions build cache
 - Web viewer development proxy configuration in `Trunk.toml` (auto-proxies `/api` and `/ws` to the server)
 - Web viewer section in README with setup instructions for both production and development modes
 - `requestAnimationFrame` batching for WebSocket board updates — coalesces rapid messages into a single paint frame for smoother 60fps animations

--- a/crates/herald-cli/src/commands/config.rs
+++ b/crates/herald-cli/src/commands/config.rs
@@ -8,6 +8,10 @@ const KNOWN_KEYS: &[&str] = &[
     "default_v_align",
     "default_color",
     "countdown_zero_behavior",
+    "theme",
+    "theme_custom_board_bg",
+    "theme_custom_tile_bg",
+    "theme_custom_char_color",
 ];
 
 fn config_description(key: &str) -> &'static str {
@@ -18,6 +22,10 @@ fn config_description(key: &str) -> &'static str {
         "default_v_align" => "Default vertical alignment (top/middle)",
         "default_color" => "Default tile color",
         "countdown_zero_behavior" => "What happens when countdown reaches zero",
+        "theme" => "Board theme (dark/classic/custom)",
+        "theme_custom_board_bg" => "Custom theme: board background (#RRGGBB)",
+        "theme_custom_tile_bg" => "Custom theme: tile background (#RRGGBB)",
+        "theme_custom_char_color" => "Custom theme: character color (#RRGGBB)",
         _ => "",
     }
 }

--- a/crates/herald-cli/src/commands/watch.rs
+++ b/crates/herald-cli/src/commands/watch.rs
@@ -98,12 +98,14 @@ async fn run_tui(
     // Animation state — pre-allocate the display buffer once and reuse it
     let mut current_display = DisplayGrid::from_board_state(&board_rx.borrow());
     let mut animation: Option<BoardAnimation> = None;
+    let mut current_theme = board_rx.borrow().theme.clone();
 
     // Frame skip: track when we last rendered to avoid catching up
     let mut last_frame_time = Instant::now();
 
     let draw = |frame: &mut ratatui::Frame,
                 display: &DisplayGrid,
+                theme: &herald_common::ThemeKind,
                 conn_state: &crate::ws_client::ConnectionState,
                 queue_info: &crate::ws_client::QueueInfoState,
                 server_url: &str,
@@ -111,7 +113,7 @@ async fn run_tui(
         let area = frame.area();
         let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(area);
 
-        frame.render_widget(BoardWidget::new(display), chunks[0]);
+        frame.render_widget(BoardWidget::new(display, theme), chunks[0]);
         frame.render_widget(
             StatusBar::new(conn_state, server_url, last_update, queue_info),
             chunks[1],
@@ -125,6 +127,7 @@ async fn run_tui(
         draw(
             frame,
             &current_display,
+            &current_theme,
             &conn_state,
             &queue_info,
             server_url,
@@ -153,6 +156,7 @@ async fn run_tui(
                 }
                 last_update = Some(Instant::now());
                 let new_board = board_rx.borrow().clone();
+                current_theme = new_board.theme.clone();
 
                 if speed == AnimationSpeed::Off {
                     // Instant transition — skip animation entirely
@@ -190,21 +194,21 @@ async fn run_tui(
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &current_theme, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = conn_rx.changed() => {
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &current_theme, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = queue_rx.changed() => {
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &current_theme, &conn_state, &queue_info, server_url, last_update);
                 })?;
             }
             _ = tokio::time::sleep(tick_duration) => {
@@ -229,7 +233,7 @@ async fn run_tui(
                 let conn_state = conn_rx.borrow().clone();
                 let queue_info = queue_rx.borrow().clone();
                 terminal.draw(|frame| {
-                    draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                    draw(frame, &current_display, &current_theme, &conn_state, &queue_info, server_url, last_update);
                 })?;
 
                 while event::poll(Duration::from_millis(0))? {
@@ -259,7 +263,7 @@ async fn run_tui(
                             let conn_state = conn_rx.borrow().clone();
                             let queue_info = queue_rx.borrow().clone();
                             terminal.draw(|frame| {
-                                draw(frame, &current_display, &conn_state, &queue_info, server_url, last_update);
+                                draw(frame, &current_display, &current_theme, &conn_state, &queue_info, server_url, last_update);
                             })?;
                         }
                         _ => {}

--- a/crates/herald-cli/src/ui/board_widget.rs
+++ b/crates/herald-cli/src/ui/board_widget.rs
@@ -1,4 +1,4 @@
-use herald_common::{BOARD_COLS, BOARD_ROWS, CellContent, Color};
+use herald_common::{BOARD_COLS, BOARD_ROWS, CellContent, Color, ThemeKind};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Position, Rect},
@@ -67,11 +67,28 @@ fn supports_256_colors() -> bool {
 /// A ratatui widget that renders the Herald 6×22 board grid with box-drawing borders.
 pub struct BoardWidget<'a> {
     display: &'a DisplayGrid,
+    theme: &'a ThemeKind,
 }
 
 impl<'a> BoardWidget<'a> {
-    pub fn new(display: &'a DisplayGrid) -> Self {
-        Self { display }
+    pub fn new(display: &'a DisplayGrid, theme: &'a ThemeKind) -> Self {
+        Self { display, theme }
+    }
+
+    /// Get the character foreground color based on the active theme.
+    fn char_color(&self) -> RatatuiColor {
+        match self.theme {
+            ThemeKind::Classic => RatatuiColor::Indexed(220), // warm yellow
+            ThemeKind::Dark | ThemeKind::Custom => RatatuiColor::Reset, // terminal default (white)
+        }
+    }
+
+    /// Get the border/grid line color based on the active theme.
+    fn border_color(&self) -> RatatuiColor {
+        match self.theme {
+            ThemeKind::Classic => RatatuiColor::Indexed(238), // dark gray
+            ThemeKind::Dark | ThemeKind::Custom => RatatuiColor::Reset,
+        }
     }
 }
 
@@ -94,6 +111,9 @@ impl<'a> Widget for BoardWidget<'a> {
         let x_offset = area.x + (area.width.saturating_sub(GRID_WIDTH)) / 2;
         let y_offset = area.y + (area.height.saturating_sub(GRID_HEIGHT)) / 2;
 
+        let border_style = Style::default().fg(self.border_color());
+        let char_style = Style::default().fg(self.char_color());
+
         // ── Draw horizontal border rows ──────────────────────────────
         for row in 0..=BOARD_ROWS as u16 {
             let y = y_offset + row * 2;
@@ -114,14 +134,14 @@ impl<'a> Widget for BoardWidget<'a> {
                 };
 
                 if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
-                    cell.set_char(junction);
+                    cell.set_char(junction).set_style(border_style);
                 }
 
                 // Horizontal dashes after the junction (except at last column)
                 if col < BOARD_COLS as u16 {
                     for dx in 1..=CELL_WIDTH {
                         if let Some(cell) = buf.cell_mut(Position::new(x + dx, y)) {
-                            cell.set_char('─');
+                            cell.set_char('─').set_style(border_style);
                         }
                     }
                 }
@@ -136,7 +156,7 @@ impl<'a> Widget for BoardWidget<'a> {
             for col in 0..=BOARD_COLS as u16 {
                 let x = x_offset + col * (CELL_WIDTH + 1);
                 if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
-                    cell.set_char('│');
+                    cell.set_char('│').set_style(border_style);
                 }
             }
 
@@ -154,7 +174,7 @@ impl<'a> Widget for BoardWidget<'a> {
                                 if let Some(cell) =
                                     buf.cell_mut(Position::new(x_start + dx as u16, y))
                                 {
-                                    cell.set_char(*ch);
+                                    cell.set_char(*ch).set_style(char_style);
                                 }
                             }
                         }
@@ -229,10 +249,15 @@ mod tests {
         DisplayGrid::from_board_state(&BoardState::default())
     }
 
+    fn default_theme() -> ThemeKind {
+        ThemeKind::Dark
+    }
+
     #[test]
     fn too_small_shows_warning() {
         let dg = blank_display();
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, 40, 5);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -252,7 +277,8 @@ mod tests {
     #[test]
     fn renders_corners() {
         let dg = blank_display();
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -280,7 +306,8 @@ mod tests {
     fn renders_char_cell() {
         let mut dg = blank_display();
         dg.cells[0][0] = CellDisplayState::Normal(CellContent::Char('H'));
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -295,7 +322,8 @@ mod tests {
     fn renders_color_cell_background() {
         let mut dg = blank_display();
         dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::Red));
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -309,7 +337,8 @@ mod tests {
     fn renders_white_color_cell_with_dark_foreground() {
         let mut dg = blank_display();
         dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::White));
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -323,7 +352,8 @@ mod tests {
     fn renders_black_color_cell_with_white_foreground() {
         let mut dg = blank_display();
         dg.cells[0][0] = CellDisplayState::Normal(CellContent::Color(Color::Black));
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);
@@ -337,7 +367,8 @@ mod tests {
     fn renders_flipping_cell() {
         let mut dg = blank_display();
         dg.cells[0][0] = CellDisplayState::Flipping('A');
-        let widget = BoardWidget::new(&dg);
+        let theme = default_theme();
+        let widget = BoardWidget::new(&dg, &theme);
         let area = Rect::new(0, 0, GRID_WIDTH, GRID_HEIGHT);
         let mut buf = Buffer::empty(area);
         widget.render(area, &mut buf);

--- a/crates/herald-common/src/types.rs
+++ b/crates/herald-common/src/types.rs
@@ -312,6 +312,68 @@ pub struct QueueItemInfo {
     pub label: String,
 }
 
+// ── Board themes ──────────────────────────────────────────────────
+
+/// Built-in board themes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemeKind {
+    /// Traditional split-flap: black background, warm yellow text.
+    Classic,
+    /// Modern minimal: dark gray background, white text.
+    #[default]
+    Dark,
+    /// User-defined colors via config.
+    Custom,
+}
+
+impl ThemeKind {
+    /// Parse a string into a ThemeKind, defaulting to Dark for unrecognized values.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "classic" => Self::Classic,
+            "dark" => Self::Dark,
+            "custom" => Self::Custom,
+            _ => Self::Dark,
+        }
+    }
+}
+
+/// Custom theme color palette (validated hex colors).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThemeColors {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub board_bg: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tile_bg: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub char_color: Option<String>,
+}
+
+impl ThemeColors {
+    /// Validate that all provided colors are valid hex colors (#RRGGBB).
+    pub fn validate(&self) -> Result<(), String> {
+        for (name, value) in [
+            ("board_bg", &self.board_bg),
+            ("tile_bg", &self.tile_bg),
+            ("char_color", &self.char_color),
+        ] {
+            if let Some(v) = value
+                && !Self::is_valid_hex(v)
+            {
+                return Err(format!(
+                    "{name} must be a valid hex color (#RRGGBB), got: {v}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn is_valid_hex(s: &str) -> bool {
+        s.len() == 7 && s.starts_with('#') && s[1..].chars().all(|c| c.is_ascii_hexdigit())
+    }
+}
+
 // ── Board state ───────────────────────────────────────────────────
 
 /// The full board state broadcast to viewers.
@@ -322,6 +384,10 @@ pub struct BoardState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_item: Option<QueueItemInfo>,
     pub timestamp: DateTime<Utc>,
+    #[serde(default)]
+    pub theme: ThemeKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme_colors: Option<ThemeColors>,
 }
 
 impl Default for BoardState {
@@ -331,6 +397,8 @@ impl Default for BoardState {
             previous_grid: Grid::blank(),
             current_item: None,
             timestamp: Utc::now(),
+            theme: ThemeKind::default(),
+            theme_colors: None,
         }
     }
 }

--- a/crates/herald-server/src/db.rs
+++ b/crates/herald-server/src/db.rs
@@ -528,7 +528,54 @@ pub async fn build_board_state(pool: &SqlitePool) -> Result<BoardState, sqlx::Er
         previous_grid: Grid::blank(),
         current_item: Some(item_info),
         timestamp: chrono::Utc::now(),
+        theme: get_theme(pool).await,
+        theme_colors: get_theme_colors(pool).await,
     })
+}
+
+/// Read the active theme from config. Defaults to Dark.
+pub async fn get_theme(pool: &SqlitePool) -> ThemeKind {
+    let row = sqlx::query("SELECT value FROM configuration WHERE key = 'theme'")
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten();
+
+    match row {
+        Some(row) => {
+            let value: String = row.get("value");
+            ThemeKind::from_str_lossy(&value)
+        }
+        None => ThemeKind::default(),
+    }
+}
+
+/// Read custom theme colors from config (only used when theme is Custom).
+pub async fn get_theme_colors(pool: &SqlitePool) -> Option<ThemeColors> {
+    let theme = get_theme(pool).await;
+    if theme != ThemeKind::Custom {
+        return None;
+    }
+
+    let config = get_config(pool).await.ok()?;
+    let colors = ThemeColors {
+        board_bg: config
+            .get("theme_custom_board_bg")
+            .and_then(|v| v.as_str().map(String::from)),
+        tile_bg: config
+            .get("theme_custom_tile_bg")
+            .and_then(|v| v.as_str().map(String::from)),
+        char_color: config
+            .get("theme_custom_char_color")
+            .and_then(|v| v.as_str().map(String::from)),
+    };
+
+    // Only return if at least one color is set
+    if colors.board_bg.is_some() || colors.tile_bg.is_some() || colors.char_color.is_some() {
+        Some(colors)
+    } else {
+        None
+    }
 }
 
 /// Advance the rotation index to the next queue item and return the new index.

--- a/crates/herald-server/src/state.rs
+++ b/crates/herald-server/src/state.rs
@@ -146,6 +146,8 @@ impl AppState {
                     previous_grid: last_grid.clone(),
                     current_item: None,
                     timestamp: chrono::Utc::now(),
+                    theme: herald_common::ThemeKind::default(),
+                    theme_colors: None,
                 };
                 drop(last_grid);
                 let _ = self

--- a/crates/herald-web/Cargo.toml
+++ b/crates/herald-web/Cargo.toml
@@ -16,7 +16,13 @@ gloo-net = { workspace = true }
 gloo-timers = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-web-sys = { workspace = true }
+web-sys = { workspace = true, features = [
+    "AudioContext", "AudioContextState", "BaseAudioContext",
+    "AudioBuffer", "AudioBufferSourceNode", "AudioScheduledSourceNode",
+    "AudioNode", "AudioParam", "AudioDestinationNode",
+    "BiquadFilterNode", "BiquadFilterType", "GainNode",
+    "MediaQueryList",
+] }
 js-sys = { workspace = true }
 log = { workspace = true }
 console_log = { workspace = true }

--- a/crates/herald-web/index.html
+++ b/crates/herald-web/index.html
@@ -317,6 +317,64 @@
             }
         }
 
+        /* ===== Theme: Classic (traditional split-flap) ===== */
+        [data-theme="classic"] {
+            --board-bg: #111;
+            --tile-top-bg: #1a1a1a;
+            --tile-bottom-bg: #161616;
+            --tile-char-color: #e8c547;
+            --tile-split-line: #0a0a0a;
+        }
+
+        [data-theme="classic"] ~ .board-status {
+            color: #b0a060;
+        }
+
+        /* ===== Theme: Custom (user-defined via config) ===== */
+        /* Custom theme colors are applied as inline CSS custom properties */
+
+        /* ===== Sound Toggle ===== */
+        .sound-toggle {
+            position: fixed;
+            bottom: 1rem;
+            left: 1rem;
+            width: 2.2rem;
+            height: 2.2rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0, 0, 0, 0.7);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+            color: #888;
+            font-size: 1rem;
+            cursor: pointer;
+            z-index: 100;
+            backdrop-filter: blur(4px);
+            -webkit-backdrop-filter: blur(4px);
+            transition: background 0.2s, border-color 0.2s, color 0.2s;
+            padding: 0;
+            line-height: 1;
+        }
+
+        .sound-toggle:hover {
+            background: rgba(0, 0, 0, 0.9);
+            border-color: rgba(255, 255, 255, 0.2);
+            color: #f0f0f0;
+        }
+
+        .sound-toggle:focus-visible {
+            outline: 2px solid #4caf50;
+            outline-offset: 2px;
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .flap-top--flipping,
+            .flap-bottom-flip {
+                animation-duration: 0.01ms !important;
+            }
+        }
+
         /* ===== Admin Panel ===== */
         .admin-container {
             min-height: 100vh;

--- a/crates/herald-web/src/admin/config.rs
+++ b/crates/herald-web/src/admin/config.rs
@@ -55,6 +55,12 @@ const CONFIG_FIELDS: &[ConfigField] = &[
         description: "What happens when a countdown reaches zero",
         input_type: InputType::Select(&["show_zero", "remove", "pause"]),
     },
+    ConfigField {
+        key: "theme",
+        label: "Board Theme",
+        description: "Visual theme for the board display",
+        input_type: InputType::Select(&["dark", "classic", "custom"]),
+    },
 ];
 
 fn get_value_str(map: &serde_json::Map<String, serde_json::Value>, key: &str) -> String {

--- a/crates/herald-web/src/components/board.rs
+++ b/crates/herald-web/src/components/board.rs
@@ -1,5 +1,4 @@
 use super::tile::FlapTile;
-use crate::components::SoundEngine;
 use crate::ws::WebSocketState;
 use herald_common::{BOARD_COLS, BOARD_ROWS};
 use leptos::prelude::*;
@@ -8,16 +7,6 @@ use leptos::prelude::*;
 /// Renders a 6×22 grid of FlapTile components using CSS Grid.
 #[component]
 pub fn Board(ws_state: WebSocketState) -> impl IntoView {
-    // Play sound cascade when changed_cols updates
-    let sound = expect_context::<SoundEngine>();
-    let changed_cols = ws_state.changed_cols;
-    Effect::new(move |_| {
-        let cols = changed_cols.get();
-        if !cols.is_empty() {
-            sound.play_cascade(&cols);
-        }
-    });
-
     view! {
         <div class="board-grid">
             {(0..BOARD_ROWS).map(|row| {

--- a/crates/herald-web/src/components/board.rs
+++ b/crates/herald-web/src/components/board.rs
@@ -1,4 +1,5 @@
 use super::tile::FlapTile;
+use crate::components::SoundEngine;
 use crate::ws::WebSocketState;
 use herald_common::{BOARD_COLS, BOARD_ROWS};
 use leptos::prelude::*;
@@ -7,6 +8,16 @@ use leptos::prelude::*;
 /// Renders a 6×22 grid of FlapTile components using CSS Grid.
 #[component]
 pub fn Board(ws_state: WebSocketState) -> impl IntoView {
+    // Play sound cascade when changed_cols updates
+    let sound = expect_context::<SoundEngine>();
+    let changed_cols = ws_state.changed_cols;
+    Effect::new(move |_| {
+        let cols = changed_cols.get();
+        if !cols.is_empty() {
+            sound.play_cascade(&cols);
+        }
+    });
+
     view! {
         <div class="board-grid">
             {(0..BOARD_ROWS).map(|row| {

--- a/crates/herald-web/src/components/mod.rs
+++ b/crates/herald-web/src/components/mod.rs
@@ -1,4 +1,6 @@
 mod board;
+mod sound;
 mod tile;
 
 pub use board::Board;
+pub use sound::SoundEngine;

--- a/crates/herald-web/src/components/sound.rs
+++ b/crates/herald-web/src/components/sound.rs
@@ -1,0 +1,226 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{AudioContext, AudioContextState, BiquadFilterType};
+
+/// Manages Web Audio API sound effects for the split-flap tile flip animation.
+///
+/// Sound is generated programmatically (no audio files): a short white-noise
+/// burst shaped by a band-pass filter and gain envelope to simulate the
+/// mechanical "clack" of a split-flap tile.
+#[derive(Clone)]
+pub struct SoundEngine {
+    context: Rc<RefCell<Option<AudioContext>>>,
+    noise_buffer: Rc<RefCell<Option<web_sys::AudioBuffer>>>,
+    /// User preference — persisted in localStorage.
+    pub enabled: RwSignal<bool>,
+    /// Whether the browser supports Web Audio.
+    pub supported: bool,
+}
+
+const STORAGE_KEY: &str = "herald_sound_enabled";
+const CLACK_DURATION_SECS: f32 = 0.03;
+const FILTER_FREQUENCY: f32 = 1200.0;
+const FILTER_Q: f32 = 2.0;
+const ATTACK_SECS: f64 = 0.001;
+const DECAY_SECS: f64 = 0.03;
+const GAIN_PEAK: f32 = 0.3;
+const CASCADE_STAGGER_SECS: f64 = 0.02;
+
+impl SoundEngine {
+    pub fn new() -> Self {
+        let supported = web_sys::window()
+            .map(|w| js_sys::Reflect::has(&w, &"AudioContext".into()).unwrap_or(false))
+            .unwrap_or(false);
+
+        // Read persisted preference (default: off)
+        let stored = load_preference();
+
+        // If prefers-reduced-motion is active, default to off regardless of stored preference
+        let reduced_motion = prefers_reduced_motion();
+        let initial_enabled = if reduced_motion { false } else { stored };
+
+        Self {
+            context: Rc::new(RefCell::new(None)),
+            noise_buffer: Rc::new(RefCell::new(None)),
+            enabled: RwSignal::new(initial_enabled),
+            supported,
+        }
+    }
+
+    /// Toggle sound on/off. Creates the AudioContext on first enable (requires user gesture).
+    pub fn toggle(&self) {
+        let new_state = !self.enabled.get_untracked();
+        self.enabled.set(new_state);
+        save_preference(new_state);
+
+        if new_state {
+            self.ensure_context();
+        } else {
+            self.suspend_context();
+        }
+    }
+
+    /// Play staggered clack sounds for the given changed columns.
+    pub fn play_cascade(&self, changed_cols: &[usize]) {
+        if !self.enabled.get_untracked() || changed_cols.is_empty() {
+            return;
+        }
+        if !self.ensure_context() {
+            return;
+        }
+
+        let ctx = self.context.borrow();
+        let ctx = match ctx.as_ref() {
+            Some(c) if c.state() == AudioContextState::Running => c,
+            _ => return,
+        };
+
+        let noise = self.noise_buffer.borrow();
+        let noise = match noise.as_ref() {
+            Some(b) => b,
+            None => return,
+        };
+
+        let now = ctx.current_time();
+        for &col in changed_cols {
+            let time = now + (col as f64) * CASCADE_STAGGER_SECS;
+            if let Err(e) = play_single_clack(ctx, noise, time) {
+                log::warn!("Failed to play clack: {:?}", e);
+                break;
+            }
+        }
+    }
+
+    /// Initialize the AudioContext if not already created.
+    /// Returns true if context is ready to use.
+    fn ensure_context(&self) -> bool {
+        let mut ctx_ref = self.context.borrow_mut();
+        if ctx_ref.is_some() {
+            // Resume if suspended
+            if let Some(ctx) = ctx_ref.as_ref() {
+                if ctx.state() == AudioContextState::Suspended {
+                    let _ = ctx.resume();
+                }
+            }
+            return true;
+        }
+
+        match AudioContext::new() {
+            Ok(ctx) => {
+                // Create the reusable noise buffer
+                match create_noise_buffer(&ctx) {
+                    Ok(buf) => {
+                        *self.noise_buffer.borrow_mut() = Some(buf);
+                    }
+                    Err(e) => {
+                        log::error!("Failed to create noise buffer: {:?}", e);
+                        return false;
+                    }
+                }
+                *ctx_ref = Some(ctx);
+                true
+            }
+            Err(e) => {
+                log::error!("Failed to create AudioContext: {:?}", e);
+                false
+            }
+        }
+    }
+
+    /// Suspend the AudioContext to save CPU when muted.
+    fn suspend_context(&self) {
+        let ctx = self.context.borrow();
+        if let Some(ctx) = ctx.as_ref() {
+            let _ = ctx.suspend();
+        }
+    }
+}
+
+/// Create a short white-noise buffer for the clack sound.
+fn create_noise_buffer(ctx: &AudioContext) -> Result<web_sys::AudioBuffer, wasm_bindgen::JsValue> {
+    let sample_rate = ctx.sample_rate();
+    let length = (sample_rate * CLACK_DURATION_SECS) as u32;
+    let buffer = ctx.create_buffer(1, length, sample_rate)?;
+
+    let data: Vec<f32> = (0..length)
+        .map(|_| js_sys::Math::random() as f32 * 2.0 - 1.0)
+        .collect();
+    buffer.copy_to_channel(&data, 0)?;
+
+    Ok(buffer)
+}
+
+/// Play a single "clack" sound at the specified time.
+fn play_single_clack(
+    ctx: &AudioContext,
+    noise: &web_sys::AudioBuffer,
+    time: f64,
+) -> Result<(), wasm_bindgen::JsValue> {
+    let source = ctx.create_buffer_source()?;
+    source.set_buffer(Some(noise));
+
+    // Band-pass filter to shape the noise into a mechanical click
+    let filter = ctx.create_biquad_filter()?;
+    filter.set_type(BiquadFilterType::Bandpass);
+    filter.frequency().set_value(FILTER_FREQUENCY);
+    filter.q().set_value(FILTER_Q);
+
+    // Gain envelope: quick attack, fast exponential decay
+    let gain = ctx.create_gain()?;
+    gain.gain().set_value_at_time(0.0, time)?;
+    gain.gain()
+        .linear_ramp_to_value_at_time(GAIN_PEAK, time + ATTACK_SECS)?;
+    gain.gain()
+        .exponential_ramp_to_value_at_time(0.001, time + ATTACK_SECS + DECAY_SECS)?;
+
+    // Connect the audio graph: source → filter → gain → destination
+    source
+        .dyn_ref::<web_sys::AudioNode>()
+        .unwrap()
+        .connect_with_audio_node(filter.dyn_ref::<web_sys::AudioNode>().unwrap())?;
+    filter
+        .dyn_ref::<web_sys::AudioNode>()
+        .unwrap()
+        .connect_with_audio_node(gain.dyn_ref::<web_sys::AudioNode>().unwrap())?;
+    gain.dyn_ref::<web_sys::AudioNode>()
+        .unwrap()
+        .connect_with_audio_node(ctx.destination().dyn_ref::<web_sys::AudioNode>().unwrap())?;
+
+    source
+        .dyn_ref::<web_sys::AudioScheduledSourceNode>()
+        .unwrap()
+        .start_with_when(time)?;
+
+    Ok(())
+}
+
+/// Check if the user prefers reduced motion.
+fn prefers_reduced_motion() -> bool {
+    web_sys::window()
+        .and_then(|w| {
+            w.match_media("(prefers-reduced-motion: reduce)")
+                .ok()
+                .flatten()
+        })
+        .map(|mq| mq.matches())
+        .unwrap_or(false)
+}
+
+/// Load sound preference from localStorage.
+fn load_preference() -> bool {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|s| s.get_item(STORAGE_KEY).ok().flatten())
+        .map(|v| v == "true")
+        .unwrap_or(false)
+}
+
+/// Save sound preference to localStorage.
+fn save_preference(enabled: bool) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(STORAGE_KEY, if enabled { "true" } else { "false" });
+    }
+}

--- a/crates/herald-web/src/main.rs
+++ b/crates/herald-web/src/main.rs
@@ -40,10 +40,6 @@ fn current_path() -> String {
 fn App() -> impl IntoView {
     let path = use_location_path();
 
-    // Provide sound engine as context (available to all components)
-    let sound = SoundEngine::new();
-    provide_context(sound.clone());
-
     view! {
         {move || {
             if path.get().starts_with("/admin") {
@@ -58,19 +54,23 @@ fn App() -> impl IntoView {
 /// The board viewer page (existing functionality).
 #[component]
 fn BoardView() -> impl IntoView {
-    let ws_state = ws::use_websocket();
+    let sound = SoundEngine::new();
+    let ws_state = ws::use_websocket(sound.clone());
+
+    let ws_for_theme = ws_state.clone();
+    let ws_for_style = ws_state.clone();
 
     view! {
         <div
             class="herald-board"
             role="img"
             aria-label="Herald message board"
-            attr:data-theme=move || theme_attr(&ws_state)
-            style=move || theme_custom_style(&ws_state)
+            attr:data-theme=move || theme_attr(&ws_for_theme)
+            style=move || theme_custom_style(&ws_for_style)
         >
             <Board ws_state=ws_state.clone() />
         </div>
-        <SoundToggle />
+        <SoundToggle sound=sound />
         <StatusBar ws_state=ws_state />
     }
 }
@@ -111,9 +111,7 @@ fn theme_custom_style(ws: &WebSocketState) -> String {
 
 /// Sound mute/unmute toggle button (bottom-left corner).
 #[component]
-fn SoundToggle() -> impl IntoView {
-    let sound = expect_context::<SoundEngine>();
-
+fn SoundToggle(sound: SoundEngine) -> impl IntoView {
     if !sound.supported {
         return view! {}.into_any();
     }

--- a/crates/herald-web/src/main.rs
+++ b/crates/herald-web/src/main.rs
@@ -3,7 +3,8 @@ mod components;
 mod ws;
 
 use admin::AdminPanel;
-use components::Board;
+use components::{Board, SoundEngine};
+use herald_common::ThemeKind;
 use leptos::prelude::*;
 use wasm_bindgen::JsCast;
 use ws::WebSocketState;
@@ -39,6 +40,10 @@ fn current_path() -> String {
 fn App() -> impl IntoView {
     let path = use_location_path();
 
+    // Provide sound engine as context (available to all components)
+    let sound = SoundEngine::new();
+    provide_context(sound.clone());
+
     view! {
         {move || {
             if path.get().starts_with("/admin") {
@@ -56,11 +61,95 @@ fn BoardView() -> impl IntoView {
     let ws_state = ws::use_websocket();
 
     view! {
-        <div class="herald-board" role="img" aria-label="Herald message board">
+        <div
+            class="herald-board"
+            role="img"
+            aria-label="Herald message board"
+            attr:data-theme=move || theme_attr(&ws_state)
+            style=move || theme_custom_style(&ws_state)
+        >
             <Board ws_state=ws_state.clone() />
         </div>
+        <SoundToggle />
         <StatusBar ws_state=ws_state />
     }
+}
+
+/// Map theme to data-theme attribute value.
+fn theme_attr(ws: &WebSocketState) -> String {
+    match ws.theme.get() {
+        ThemeKind::Classic => "classic".to_string(),
+        ThemeKind::Dark => "dark".to_string(),
+        ThemeKind::Custom => "custom".to_string(),
+    }
+}
+
+/// Generate inline CSS custom properties for custom theme colors.
+fn theme_custom_style(ws: &WebSocketState) -> String {
+    if ws.theme.get() != ThemeKind::Custom {
+        return String::new();
+    }
+
+    let colors = ws.theme_colors.get();
+    let colors = match colors.as_ref() {
+        Some(c) => c,
+        None => return String::new(),
+    };
+
+    let mut style = String::new();
+    if let Some(bg) = &colors.board_bg {
+        style.push_str(&format!("--board-bg:{bg};--body-bg:{bg};"));
+    }
+    if let Some(tile) = &colors.tile_bg {
+        style.push_str(&format!("--tile-top-bg:{tile};--tile-bottom-bg:{tile};"));
+    }
+    if let Some(ch) = &colors.char_color {
+        style.push_str(&format!("--tile-char-color:{ch};"));
+    }
+    style
+}
+
+/// Sound mute/unmute toggle button (bottom-left corner).
+#[component]
+fn SoundToggle() -> impl IntoView {
+    let sound = expect_context::<SoundEngine>();
+
+    if !sound.supported {
+        return view! {}.into_any();
+    }
+
+    let on_click = {
+        let sound = sound.clone();
+        move |_| sound.toggle()
+    };
+
+    let icon = move || {
+        if sound.enabled.get() {
+            "\u{1F50A}" // 🔊
+        } else {
+            "\u{1F507}" // 🔇
+        }
+    };
+
+    let label = move || {
+        if sound.enabled.get() {
+            "Mute flip sound"
+        } else {
+            "Enable flip sound"
+        }
+    };
+
+    view! {
+        <button
+            class="sound-toggle"
+            on:click=on_click
+            aria-label=label
+            title=label
+        >
+            {icon}
+        </button>
+    }
+    .into_any()
 }
 
 /// Fixed-position connection status indicator (bottom-right).

--- a/crates/herald-web/src/ws.rs
+++ b/crates/herald-web/src/ws.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::components::SoundEngine;
 use futures::StreamExt;
 use gloo_net::websocket::{Message, futures::WebSocket};
 use gloo_timers::future::TimeoutFuture;
@@ -43,7 +44,7 @@ fn ws_url() -> String {
 
 /// Create and manage a WebSocket connection with reconnection logic.
 /// Returns reactive state that updates when board state changes.
-pub fn use_websocket() -> WebSocketState {
+pub fn use_websocket(sound: SoundEngine) -> WebSocketState {
     let grid: Vec<Vec<RwSignal<CellContent>>> = (0..BOARD_ROWS)
         .map(|_| {
             (0..BOARD_COLS)
@@ -79,7 +80,7 @@ pub fn use_websocket() -> WebSocketState {
     };
 
     let state_clone = state.clone();
-    let batcher = RafBatcher::new(state_clone);
+    let batcher = RafBatcher::new(state_clone, sound);
     spawn_local(async move {
         connection_loop(batcher).await;
     });
@@ -96,14 +97,16 @@ struct RafBatcher {
     pending: Rc<RefCell<Option<BoardState>>>,
     raf_scheduled: Rc<RefCell<bool>>,
     state: WebSocketState,
+    sound: SoundEngine,
 }
 
 impl RafBatcher {
-    fn new(state: WebSocketState) -> Self {
+    fn new(state: WebSocketState, sound: SoundEngine) -> Self {
         Self {
             pending: Rc::new(RefCell::new(None)),
             raf_scheduled: Rc::new(RefCell::new(false)),
             state,
+            sound,
         }
     }
 
@@ -117,11 +120,17 @@ impl RafBatcher {
             let pending = Rc::clone(&self.pending);
             let raf_scheduled = Rc::clone(&self.raf_scheduled);
             let state = self.state.clone();
+            let sound = self.sound.clone();
 
             let closure = Closure::once(move || {
                 *raf_scheduled.borrow_mut() = false;
                 if let Some(board_state) = pending.borrow_mut().take() {
                     apply_board_update(&board_state, &state);
+                    // Trigger sound for changed columns
+                    let cols = state.changed_cols.get_untracked();
+                    if !cols.is_empty() {
+                        sound.play_cascade(&cols);
+                    }
                 }
             });
 

--- a/crates/herald-web/src/ws.rs
+++ b/crates/herald-web/src/ws.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use futures::StreamExt;
 use gloo_net::websocket::{Message, futures::WebSocket};
 use gloo_timers::future::TimeoutFuture;
-use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent, ServerMessage};
+use herald_common::{BOARD_COLS, BOARD_ROWS, BoardState, CellContent, ServerMessage, ThemeKind};
 use leptos::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
@@ -23,6 +23,12 @@ pub struct WebSocketState {
     pub has_received_update: RwSignal<bool>,
     /// Trigger signal that increments on each board update (used to start animations)
     pub update_counter: RwSignal<u64>,
+    /// Columns that changed in the most recent board update (for sound effects)
+    pub changed_cols: RwSignal<Vec<usize>>,
+    /// Current board theme
+    pub theme: RwSignal<ThemeKind>,
+    /// Custom theme colors (only populated when theme is Custom)
+    pub theme_colors: RwSignal<Option<herald_common::ThemeColors>>,
 }
 
 /// Derive the WebSocket URL from the current page location.
@@ -57,6 +63,9 @@ pub fn use_websocket() -> WebSocketState {
     let connected = RwSignal::new(false);
     let has_received_update = RwSignal::new(false);
     let update_counter = RwSignal::new(0u64);
+    let changed_cols = RwSignal::new(Vec::new());
+    let theme = RwSignal::new(ThemeKind::default());
+    let theme_colors = RwSignal::new(None);
 
     let state = WebSocketState {
         grid,
@@ -64,6 +73,9 @@ pub fn use_websocket() -> WebSocketState {
         connected,
         has_received_update,
         update_counter,
+        changed_cols,
+        theme,
+        theme_colors,
     };
 
     let state_clone = state.clone();
@@ -200,6 +212,25 @@ fn handle_message(text: &str, batcher: &RafBatcher) {
 
 /// Apply a board update to the reactive grid signals.
 fn apply_board_update(board_state: &BoardState, state: &WebSocketState) {
+    // Compute changed columns for sound by comparing current client display with new grid.
+    // Only compute if we've already received at least one update (suppress initial/reconnect).
+    let already_received = state.has_received_update.get_untracked();
+    if already_received {
+        let mut cols = Vec::new();
+        for col in 0..BOARD_COLS {
+            for row in 0..BOARD_ROWS {
+                let current = state.grid[row][col].get_untracked();
+                if current != board_state.grid.0[row][col] {
+                    cols.push(col);
+                    break;
+                }
+            }
+        }
+        state.changed_cols.set(cols);
+    } else {
+        state.changed_cols.set(vec![]);
+    }
+
     // Copy current grid to previous_grid signals before updating
     for row in 0..BOARD_ROWS {
         for col in 0..BOARD_COLS {
@@ -215,6 +246,10 @@ fn apply_board_update(board_state: &BoardState, state: &WebSocketState) {
             state.grid[row][col].set(new_cell);
         }
     }
+
+    // Update theme
+    state.theme.set(board_state.theme.clone());
+    state.theme_colors.set(board_state.theme_colors.clone());
 
     // Mark that we've received at least one update
     if !state.has_received_update.get_untracked() {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -64,6 +64,7 @@ Pushing a `v*` tag triggers the **Release** workflow which:
 3. Extracts release notes from CHANGELOG.md
 4. Creates a GitHub Release with all artifacts attached
 5. Marks `0.x.y` releases as pre-release automatically
+6. Builds and pushes a Docker image to `ghcr.io/kafkade/herald` tagged with the version (e.g. `0.5.2`, `0.5`)
 
 ### 5. Verify
 
@@ -87,3 +88,4 @@ Each release includes:
 | `herald-server-vX.Y.Z-<target>.tar.gz` | Binary archive (Linux/macOS) |
 | `herald-server-vX.Y.Z-<target>.zip` | Binary archive (Windows) |
 | `herald-server-vX.Y.Z-<target>.*.sha256` | SHA-256 checksum |
+| `ghcr.io/kafkade/herald:X.Y.Z` | Docker image (linux/amd64) |


### PR DESCRIPTION
## Description

Add flip sound effects, a mute/unmute toggle, board theme support, and Docker image publishing to the release workflow.

### What's included

- **Clack sound effect** (#69): Programmatic Web Audio API synthesis (white noise → band-pass filter → gain envelope) that plays a mechanical "clack" on each tile flip, staggered 20ms per column to match the visual cascade. Sound is off by default; prefers-reduced-motion keeps it disabled.
- **Mute/unmute toggle** (#70): Speaker icon button (🔊/🔇) fixed to the bottom-left corner. Keyboard-focusable with aria-label. Preference persisted in localStorage. When muted, the AudioContext is suspended (zero CPU).
- **Board themes** (#71): Three built-in themes — Classic (warm yellow on black), Dark (white on dark gray, default), and Custom (user-defined #RRGGBB hex colors via config). Themes are selectable from the admin config panel or via herald config set theme <name>. Web viewer swaps CSS custom properties via data-theme; CLI viewer applies ANSI color palettes.
- **Release Docker image** (#66): New docker job in the release workflow builds and pushes to ghcr.io/kafkade/herald with semver tags, using Buildx and GitHub Actions cache.

## Related Issues

Closes #66, closes #69, closes #70, closes #71

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [x] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` reports no warnings
- [x] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [x] I have updated documentation (if applicable)