### PR TITLE
Group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      cargo:
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -25,3 +29,7 @@ updates:
       - "ci"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Dependabot currently opens a separate pull request for every dependency bump, which creates review noise and churn across the Cargo and GitHub Actions ecosystems. This change enables grouped updates so each ecosystem produces a single consolidated PR per run.

Each `updates:` entry in `.github/dependabot.yml` now has a `groups:` block keyed by the ecosystem name with `patterns: ["*"]`, bundling all of that ecosystem's dependencies together. All existing keys (schedule, commit-message, labels, open-pull-requests-limit, directory) are preserved unchanged.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Checklist

- [ ] I have read [CONTRIBUTING.md](docs/CONTRIBUTING.md)
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` reports no warnings
- [ ] `cargo fmt` has been applied
- [ ] I have added tests for new functionality (if applicable)
- [ ] I have updated documentation (if applicable)

> Config-only change to `.github/dependabot.yml`; no Rust code touched, so the cargo checks above are not applicable.